### PR TITLE
Add filtering by tags to forums lists

### DIFF
--- a/Source/Networking/AwfulHTTPClient.h
+++ b/Source/Networking/AwfulHTTPClient.h
@@ -31,6 +31,7 @@
 //
 // Returns the enqueued network operation.
 - (NSOperation *)listThreadsInForumWithID:(NSString *)forumID
+                                threadTag:(NSString*)tag
                                    onPage:(NSInteger)page
                                   andThen:(void (^)(NSError *error, NSArray *threads))callback;
 

--- a/Source/Networking/AwfulHTTPClient.m
+++ b/Source/Networking/AwfulHTTPClient.m
@@ -131,14 +131,19 @@ static AwfulHTTPClient *instance = nil;
 }
 
 - (NSOperation *)listThreadsInForumWithID:(NSString *)forumID
+                                threadTag:(NSString*)tag
                                    onPage:(NSInteger)page
                                   andThen:(void (^)(NSError *error, NSArray *threads))callback
 {
-    NSDictionary *parameters = @{
+    NSMutableDictionary *parameters = [@{
         @"forumid": forumID,
         @"perpage": @40,
         @"pagenumber": @(page),
-    };
+    } mutableCopy];
+    if (tag) {
+        parameters[@"posticon"] = tag;
+    }
+
     NSURLRequest *request = [self requestWithMethod:@"GET" path:@"forumdisplay.php"
                                          parameters:parameters];
     id op = [self HTTPRequestOperationWithRequest:request

--- a/Source/Thread Tags/AwfulThreadTagFilterController.h
+++ b/Source/Thread Tags/AwfulThreadTagFilterController.h
@@ -1,0 +1,11 @@
+//  AwfulThreadTagFilterViewController.h
+//
+//  Copyright 2013 Awful Contributors. CC BY-NC-SA 3.0 US https://github.com/Awful/Awful.app
+
+#import "AwfulPostIconPickerController.h"
+
+@interface AwfulThreadTagFilterController : AwfulPostIconPickerController
+
+- (void)showFromBarButtonItem:(UIBarButtonItem*)barButtonItem;
+
+@end

--- a/Source/Thread Tags/AwfulThreadTagFilterController.m
+++ b/Source/Thread Tags/AwfulThreadTagFilterController.m
@@ -1,0 +1,45 @@
+//  AwfulThreadTagFilterController.m
+//
+//  Copyright 2013 Awful Contributors. CC BY-NC-SA 3.0 US https://github.com/Awful/Awful.app
+
+#import "AwfulThreadTagFilterController.h"
+
+@interface AwfulThreadTagFilterController () <UIPopoverControllerDelegate>
+
+@property (nonatomic) UIBarButtonItem *pickButtonItem;
+@property (nonatomic) UIPopoverController *popover;
+
+@end
+
+
+@implementation AwfulThreadTagFilterController
+
+- (instancetype)initWithDelegate:(id <AwfulPostIconPickerControllerDelegate>)delegate
+{
+    if (self = [super initWithDelegate:delegate]) {
+        self.title = @"Filter Posts";
+    }
+    return self;
+}
+
+- (UIBarButtonItem *)pickButtonItem
+{
+    if (_pickButtonItem) return _pickButtonItem;
+    _pickButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Filter" style:UIBarButtonItemStyleDone
+                                                      target:self action:@selector(didTapPick)];
+    return _pickButtonItem;
+}
+
+- (void)showFromBarButtonItem:(UIBarButtonItem*)barButtonItem
+{
+    if (UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPad) return;
+    if (!self.popover) {
+        self.popover = [[UIPopoverController alloc] initWithContentViewController:self];
+        self.popover.delegate = self;
+    }
+    [self.popover presentPopoverFromBarButtonItem:barButtonItem
+                         permittedArrowDirections:UIPopoverArrowDirectionAny
+                                         animated:YES];
+}
+
+@end

--- a/Source/Threads/AwfulBookmarksController.m
+++ b/Source/Threads/AwfulBookmarksController.m
@@ -36,7 +36,7 @@
                                                              target:nil
                                                              action:NULL];
     self.navigationItem.backBarButtonItem = marks;
-    self.navigationItem.rightBarButtonItem = nil;
+    self.navigationItem.rightBarButtonItems = nil;
     return self;
 }
 

--- a/Xcode/Awful.xcodeproj/project.pbxproj
+++ b/Xcode/Awful.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0318740017EBCF3C001C31BF /* AwfulThreadTagFilterController.m in Sources */ = {isa = PBXBuildFile; fileRef = 031873FF17EBCF3C001C31BF /* AwfulThreadTagFilterController.m */; };
 		10D34FA9128F41160026C7C2 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 10D34FA8128F41160026C7C2 /* CFNetwork.framework */; };
 		10D34FAF128F413C0026C7C2 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 10D34FAE128F413C0026C7C2 /* MobileCoreServices.framework */; };
 		10D34FB1128F413C0026C7C2 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 10D34FB0128F413C0026C7C2 /* SystemConfiguration.framework */; };
@@ -358,6 +359,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		031873FE17EBCF3C001C31BF /* AwfulThreadTagFilterController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AwfulThreadTagFilterController.h; sourceTree = "<group>"; };
+		031873FF17EBCF3C001C31BF /* AwfulThreadTagFilterController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AwfulThreadTagFilterController.m; sourceTree = "<group>"; };
 		10D34FA8128F41160026C7C2 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		10D34FAE128F413C0026C7C2 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		10D34FB0128F413C0026C7C2 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -1069,6 +1072,8 @@
 				1C3447C7174D7284007377C5 /* AwfulThreadTagView.m */,
 				1C3447D0174D9B01007377C5 /* AwfulThreadTagButton.h */,
 				1C3447D1174D9B01007377C5 /* AwfulThreadTagButton.m */,
+				031873FE17EBCF3C001C31BF /* AwfulThreadTagFilterController.h */,
+				031873FF17EBCF3C001C31BF /* AwfulThreadTagFilterController.m */,
 			);
 			path = "Thread Tags";
 			sourceTree = "<group>";
@@ -2327,6 +2332,7 @@
 				1C3447E1175D9991007377C5 /* AwfulPostViewModel.m in Sources */,
 				1C3447E7175DAAAD007377C5 /* AwfulProfileViewModel.m in Sources */,
 				1C3447EC175E5D78007377C5 /* AwfulLoadingView.m in Sources */,
+				0318740017EBCF3C001C31BF /* AwfulThreadTagFilterController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This adds thread filtering functionality to forum list views. Functionally it's fine (with the below caveat), but maybe TheDave or Diabolik might want to knock up a quick "filter" icon rather than using the built-in search icon, and also pick a better colour than yellowColor for the "active" state.

There is one outstanding issue; if you filter a forum, kill the app and come back within the 15 minute refresh timeout period, the filter will still be active but the icon isn't coloured to show that a filter's active. I think postIcon.composeID should be persisted to fix this (and checked when the view initialises), but I've never used CoreData and have heard scary things about modifying the data models, so I think it's safer for me to leave it to someone who knows what they're doing. Alternatively if there are ideas for an alternative solution I can take a look.
