### PR TITLE
Long pressing on YouTube video links now display "Open in YouTube" in…

### DIFF
--- a/App/In-App Actions/URLMenuPresenter.swift
+++ b/App/In-App Actions/URLMenuPresenter.swift
@@ -51,7 +51,13 @@ private enum _URLMenuPresenter {
                     }))
                     
                 case AwfulDefaultBrowserSafari:
-                    alert.addAction(UIAlertAction(title: "Open in Safari", style: .Default, handler: { _ in
+                    let title: String
+                    if canOpenInYouTube(linkURL) {
+                        title = "Open in YouTube"
+                    } else {
+                        title = "Open in Safari"
+                    }
+                    alert.addAction(UIAlertAction(title: title, style: .Default, handler: { _ in
                         UIApplication.sharedApplication().openURL(linkURL)
                         return
                     }))
@@ -180,6 +186,21 @@ private func chromifyURL(URL: NSURL) -> NSURL {
         components.scheme = "googlechromes"
     }
     return components.URL!
+}
+
+private func canOpenInYouTube(URL: NSURL) -> Bool {
+    let installed = UIApplication.sharedApplication().canOpenURL(NSURL(string:"youtube://")!)
+    let host = URL.host?.lowercaseString
+    let query = URL.query?.lowercaseString
+    let path = URL.path?.lowercaseString
+    if installed == true
+        && host?.hasSuffix("youtube.com") == true
+        && path?.hasPrefix("/watch") == true
+        && query?.hasPrefix("v=") == true {
+            
+        return true
+    }
+    return false
 }
 
 /// Presents a menu for a link or a video.


### PR DESCRIPTION
… place of "Open in Safari" when YouTube is installed

I think this is the only way people would get links from either the browser or the app to paste into their posts, but I can add in other URL formats if needed. Let me know if you have any suggestions.