### PR TITLE
Add Peek and Pop function to thread lists

### DIFF
--- a/App/Posts/PostsPageViewController.h
+++ b/App/Posts/PostsPageViewController.h
@@ -19,7 +19,7 @@
 /**
  * Calls -initWithThread:author: with a nil author.
  */
-- (instancetype)initWithThread:(Thread *)thread noSeen:(bool)noSeen;
+- (instancetype)initWithThread:(Thread *)thread;
 
 @property (readonly, strong, nonatomic) Thread *thread;
 

--- a/App/Posts/PostsPageViewController.h
+++ b/App/Posts/PostsPageViewController.h
@@ -44,7 +44,7 @@
  * @param page        The page to load. Values of AwfulThreadPage are allowed here too (but it's typed NSInteger for Swift compatibility).
  * @param updateCache Whether to fetch posts from the client, or simply render any posts that are cached.
  */
-- (void)loadPage:(NSInteger)page updatingCache:(BOOL)updateCache;
+- (void)loadPage:(NSInteger)page updatingCache:(BOOL)updateCache noSeen:(BOOL)notSeen;
 
 /**
  * An array of AwfulPost objects of the currently-visible posts.

--- a/App/Posts/PostsPageViewController.h
+++ b/App/Posts/PostsPageViewController.h
@@ -19,7 +19,7 @@
 /**
  * Calls -initWithThread:author: with a nil author.
  */
-- (instancetype)initWithThread:(Thread *)thread;
+- (instancetype)initWithThread:(Thread *)thread noSeen:(bool)noSeen;
 
 @property (readonly, strong, nonatomic) Thread *thread;
 

--- a/App/Posts/PostsPageViewController.m
+++ b/App/Posts/PostsPageViewController.m
@@ -55,7 +55,6 @@
     NSString *_jumpToPostIDAfterLoading;
     CGFloat _scrollToFractionAfterLoading;
     BOOL _restoringState;
-    BOOL _noSeen;
 }
 
 - (void)dealloc
@@ -93,9 +92,8 @@
     return self;
 }
 
-- (instancetype)initWithThread:(Thread *)thread noSeen:(bool)noSeen
+- (instancetype)initWithThread:(Thread *)thread
 {
-    _noSeen = noSeen;
     return [self initWithThread:thread author:nil];
 }
 
@@ -166,7 +164,6 @@
     self.networkOperation = [[AwfulForumsClient client] listPostsInThread:self.thread
                                                                 writtenBy:self.author
                                                                    onPage:self.page
-                                                                   noSeen:_noSeen
                                                                   andThen:^(NSError *error, NSArray *posts, NSUInteger firstUnreadPost, NSString *advertisementHTML)
     {
         __typeof__(self) self = weakSelf;
@@ -217,12 +214,10 @@
         [self updateUserInterface];
         
         Post *lastPost = self.posts.lastObject;
-        if(!_noSeen)
-        {
-            if (self.thread.seenPosts < lastPost.threadIndex) {
-                self.thread.seenPosts = lastPost.threadIndex;
-            }
+        if (self.thread.seenPosts < lastPost.threadIndex) {
+            self.thread.seenPosts = lastPost.threadIndex;
         }
+        
         [self.postsView.webView.scrollView.pullToRefreshView stopAnimating];
     }];
 }

--- a/App/Posts/PostsPageViewController.m
+++ b/App/Posts/PostsPageViewController.m
@@ -223,6 +223,9 @@
                 self.thread.seenPosts = lastPost.threadIndex;
             }
         }
+        // noSeen should only be respected for the first initial load (Ex. The Peek View Controller).
+        // after that, it will start marking all posts as seen.
+        _noSeen = NO;
         [self.postsView.webView.scrollView.pullToRefreshView stopAnimating];
     }];
 }

--- a/App/Posts/PostsPageViewController.m
+++ b/App/Posts/PostsPageViewController.m
@@ -124,7 +124,7 @@
     }
 }
 
-- (void)loadPage:(NSInteger)page updatingCache:(BOOL)updateCache
+- (void)loadPage:(NSInteger)page updatingCache:(BOOL)updateCache noSeen:(BOOL)notSeen
 {
     [self.networkOperation cancel];
     self.networkOperation = nil;
@@ -164,6 +164,7 @@
     self.networkOperation = [[AwfulForumsClient client] listPostsInThread:self.thread
                                                                 writtenBy:self.author
                                                                    onPage:self.page
+                                                                   noSeen:notSeen
                                                                   andThen:^(NSError *error, NSArray *posts, NSUInteger firstUnreadPost, NSString *advertisementHTML)
     {
         __typeof__(self) self = weakSelf;
@@ -329,7 +330,7 @@ typedef void (^ReplyCompletion)(BOOL, BOOL);
             self.replyWorkspace = nil;
         }
         if (didSucceed) {
-            [self loadPage:AwfulThreadPageNextUnread updatingCache:YES];
+            [self loadPage:AwfulThreadPageNextUnread updatingCache:YES noSeen:NO];
         }
         [self dismissViewControllerAnimated:YES completion:nil];
     };
@@ -360,7 +361,7 @@ typedef void (^ReplyCompletion)(BOOL, BOOL);
     _backItem.awful_actionBlock = ^(UIBarButtonItem *sender) {
         __typeof__(self) self = weakSelf;
         if (self.page > 1) {
-            [self loadPage:self.page - 1 updatingCache:YES];
+            [self loadPage:self.page - 1 updatingCache:YES noSeen:NO];
         }
     };
     return _backItem;
@@ -392,7 +393,7 @@ typedef void (^ReplyCompletion)(BOOL, BOOL);
     _forwardItem.awful_actionBlock = ^(UIBarButtonItem *sender) {
         __typeof__(self) self = weakSelf;
         if (self.page < self.numberOfPages && self.page > 0) {
-            [self loadPage:self.page + 1 updatingCache:YES];
+            [self loadPage:self.page + 1 updatingCache:YES noSeen:NO];
         }
     };
     return _forwardItem;
@@ -647,7 +648,7 @@ typedef void (^ReplyCompletion)(BOOL, BOOL);
         nextPage = self.page + 1;
     }
     
-    [self loadPage:nextPage updatingCache:YES];
+    [self loadPage:nextPage updatingCache:YES noSeen:NO];
 }
 
 - (void)goToParentForum
@@ -752,7 +753,7 @@ typedef void (^ReplyCompletion)(BOOL, BOOL);
 		[items addObject:[AwfulIconActionItem itemWithType:AwfulIconActionItemTypeSingleUsersPosts action:^{
             PostsPageViewController *postsView = [[PostsPageViewController alloc] initWithThread:self.thread author:user];
             postsView.restorationIdentifier = @"Just their posts";
-            [postsView loadPage:1 updatingCache:YES];
+            [postsView loadPage:1 updatingCache:YES noSeen:NO];
             [self.navigationController pushViewController:postsView animated:YES];
         }]];
 	}
@@ -1149,9 +1150,9 @@ didFinishWithSuccessfulSubmission:(BOOL)success
     self.messageViewController.delegate = self;
     self.hiddenPosts = [coder decodeIntegerForKey:HiddenPostsKey];
     self.page = [coder decodeIntegerForKey:PageKey];
-    [self loadPage:self.page updatingCache:NO];
+    [self loadPage:self.page updatingCache:NO noSeen:NO];
     if (self.posts.count == 0) {
-        [self loadPage:self.page updatingCache:YES];
+        [self loadPage:self.page updatingCache:YES noSeen:NO];
     }
     self.advertisementHTML = [coder decodeObjectForKey:AdvertisementHTMLKey];
     _scrollToFractionAfterLoading = [coder decodeFloatForKey:ScrolledFractionOfContentKey];

--- a/App/Posts/PostsPageViewController.m
+++ b/App/Posts/PostsPageViewController.m
@@ -223,9 +223,6 @@
                 self.thread.seenPosts = lastPost.threadIndex;
             }
         }
-        // noSeen should only be respected for the first initial load (Ex. The Peek View Controller).
-        // after that, it will start marking all posts as seen.
-        _noSeen = NO;
         [self.postsView.webView.scrollView.pullToRefreshView stopAnimating];
     }];
 }

--- a/App/Posts/PostsPageViewController.m
+++ b/App/Posts/PostsPageViewController.m
@@ -1168,6 +1168,68 @@ didFinishWithSuccessfulSubmission:(BOOL)success
     _restoringState = NO;
 }
 
+#pragma mark - Preview Actions
+
+- (NSArray<id<UIPreviewActionItem>> *)previewActionItems {
+    
+    // setup a list of preview actions
+    UIPreviewAction *action1 = [UIPreviewAction actionWithTitle:@"Copy URL" style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+        NSURLComponents *components = [NSURLComponents componentsWithString:@"http://forums.somethingawful.com/showthread.php"];
+        NSMutableArray *queryParts = [NSMutableArray new];
+        [queryParts addObject:[NSString stringWithFormat:@"threadid=%@", self.thread.threadID]];
+        [queryParts addObject:@"perpage=40"];
+        if (self.page > 1) {
+            [queryParts addObject:[NSString stringWithFormat:@"pagenumber=%@", @(self.page)]];
+        }
+        components.query = [queryParts componentsJoinedByString:@"&"];
+        NSURL *URL = components.URL;
+        [AwfulSettings sharedSettings].lastOfferedPasteboardURL = URL.absoluteString;
+        [UIPasteboard generalPasteboard].awful_URL = URL;
+    }];
+    
+    NSString *title;
+    UIPreviewActionStyle bookmarkStyle;
+    if (self.thread.bookmarked) {
+        title = @"Remove Bookmark";
+        bookmarkStyle = UIPreviewActionStyleDestructive;
+    } else {
+        title = @"Add Bookmark";
+        bookmarkStyle = UIPreviewActionStyleDefault;
+    }
+    
+    UIPreviewAction *action2 = [UIPreviewAction actionWithTitle:title style:bookmarkStyle handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+        [[AwfulForumsClient client] setThread:self.thread
+                                 isBookmarked:!self.thread.bookmarked
+                                      andThen:^(NSError *error)
+         {
+             if (error) {
+                 NSLog(@"error %@bookmarking thread %@: %@",
+                       self.thread.bookmarked ? @"un" : @"", self.thread.threadID, error);
+             } else {
+                 NSString *status = @"Removed Bookmark";
+                 if (self.thread.bookmarked) {
+                     status = @"Added Bookmark";
+                 }
+                 MRProgressOverlayView *overlay = [MRProgressOverlayView showOverlayAddedTo:self.view
+                                                                                      title:status
+                                                                                       mode:MRProgressOverlayViewModeCheckmark
+                                                                                   animated:YES];
+                 //                 overlay.tintColor = self.theme[@"tintColor"];
+                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.7 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                     [overlay dismiss:YES];
+                 });
+             }
+         }];
+
+    }];
+    
+    // add them to an arrary
+    NSArray *actions = @[action1, action2];
+    
+    // and return them
+    return actions;
+}
+
 static NSString * const ThreadKeyKey = @"ThreadKey";
 static NSString * const obsolete_ThreadIDKey = @"AwfulThreadID";
 static NSString * const PageKey = @"AwfulCurrentPage";

--- a/App/Posts/PostsPageViewController.m
+++ b/App/Posts/PostsPageViewController.m
@@ -215,8 +215,11 @@
         [self updateUserInterface];
         
         Post *lastPost = self.posts.lastObject;
-        if (self.thread.seenPosts < lastPost.threadIndex) {
-            self.thread.seenPosts = lastPost.threadIndex;
+        if(!notSeen)
+        {
+            if (self.thread.seenPosts < lastPost.threadIndex) {
+                self.thread.seenPosts = lastPost.threadIndex;
+            }
         }
         
         [self.postsView.webView.scrollView.pullToRefreshView stopAnimating];

--- a/App/Posts/PostsPageViewController.m
+++ b/App/Posts/PostsPageViewController.m
@@ -55,6 +55,7 @@
     NSString *_jumpToPostIDAfterLoading;
     CGFloat _scrollToFractionAfterLoading;
     BOOL _restoringState;
+    BOOL _noSeen;
 }
 
 - (void)dealloc
@@ -92,8 +93,9 @@
     return self;
 }
 
-- (instancetype)initWithThread:(Thread *)thread
+- (instancetype)initWithThread:(Thread *)thread noSeen:(bool)noSeen
 {
+    _noSeen = noSeen;
     return [self initWithThread:thread author:nil];
 }
 
@@ -164,6 +166,7 @@
     self.networkOperation = [[AwfulForumsClient client] listPostsInThread:self.thread
                                                                 writtenBy:self.author
                                                                    onPage:self.page
+                                                                   noSeen:_noSeen
                                                                   andThen:^(NSError *error, NSArray *posts, NSUInteger firstUnreadPost, NSString *advertisementHTML)
     {
         __typeof__(self) self = weakSelf;
@@ -214,10 +217,12 @@
         [self updateUserInterface];
         
         Post *lastPost = self.posts.lastObject;
-        if (self.thread.seenPosts < lastPost.threadIndex) {
-            self.thread.seenPosts = lastPost.threadIndex;
+        if(!_noSeen)
+        {
+            if (self.thread.seenPosts < lastPost.threadIndex) {
+                self.thread.seenPosts = lastPost.threadIndex;
+            }
         }
-        
         [self.postsView.webView.scrollView.pullToRefreshView stopAnimating];
     }];
 }

--- a/App/Posts/PostsPageViewController.m
+++ b/App/Posts/PostsPageViewController.m
@@ -1187,6 +1187,11 @@ didFinishWithSuccessfulSubmission:(BOOL)success
         [UIPasteboard generalPasteboard].awful_URL = URL;
     }];
     
+    
+    UIPreviewAction *action2 = [UIPreviewAction actionWithTitle:@"Mark Thread As Read" style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+        [self loadPage:self.numberOfPages updatingCache:YES noSeen:NO];
+    }];
+    
     NSString *title;
     UIPreviewActionStyle bookmarkStyle;
     if (self.thread.bookmarked) {
@@ -1197,7 +1202,7 @@ didFinishWithSuccessfulSubmission:(BOOL)success
         bookmarkStyle = UIPreviewActionStyleDefault;
     }
     
-    UIPreviewAction *action2 = [UIPreviewAction actionWithTitle:title style:bookmarkStyle handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+    UIPreviewAction *action3 = [UIPreviewAction actionWithTitle:title style:bookmarkStyle handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
         [[AwfulForumsClient client] setThread:self.thread
                                  isBookmarked:!self.thread.bookmarked
                                       andThen:^(NSError *error)
@@ -1224,7 +1229,7 @@ didFinishWithSuccessfulSubmission:(BOOL)success
     }];
     
     // add them to an arrary
-    NSArray *actions = @[action1, action2];
+    NSArray *actions = @[action1, action2, action3];
     
     // and return them
     return actions;

--- a/App/Posts/Selectotron.swift
+++ b/App/Posts/Selectotron.swift
@@ -35,7 +35,7 @@ final class Selectotron : AwfulViewController {
     }
     
     private func dismissAndLoadPage(page: Int) {
-        postsViewController.loadPage(page, updatingCache: true)
+        postsViewController.loadPage(page, updatingCache: true, noSeen: false)
         dismissViewControllerAnimated(true, completion: nil)
     }
     

--- a/App/Threads/ForumSpecificThreadListViewController.swift
+++ b/App/Threads/ForumSpecificThreadListViewController.swift
@@ -245,7 +245,7 @@ extension ForumSpecificThreadListViewController: AwfulComposeTextViewControllerD
         dismissViewControllerAnimated(true) {
             if success {
                 if let thread = self.threadComposeViewController?.thread {
-                    let postsPage = PostsPageViewController(thread: thread)
+                    let postsPage = PostsPageViewController(thread: thread, noSeen: false)
                     postsPage.restorationIdentifier = "Posts"
                     postsPage.loadPage(1, updatingCache: true)
                     self.showDetailViewController(postsPage, sender: self)

--- a/App/Threads/ForumSpecificThreadListViewController.swift
+++ b/App/Threads/ForumSpecificThreadListViewController.swift
@@ -247,7 +247,7 @@ extension ForumSpecificThreadListViewController: AwfulComposeTextViewControllerD
                 if let thread = self.threadComposeViewController?.thread {
                     let postsPage = PostsPageViewController(thread: thread)
                     postsPage.restorationIdentifier = "Posts"
-                    postsPage.loadPage(1, updatingCache: true)
+                    postsPage.loadPage(1, updatingCache: true, noSeen: false)
                     self.showDetailViewController(postsPage, sender: self)
                 }
             }

--- a/App/Threads/ForumSpecificThreadListViewController.swift
+++ b/App/Threads/ForumSpecificThreadListViewController.swift
@@ -245,7 +245,7 @@ extension ForumSpecificThreadListViewController: AwfulComposeTextViewControllerD
         dismissViewControllerAnimated(true) {
             if success {
                 if let thread = self.threadComposeViewController?.thread {
-                    let postsPage = PostsPageViewController(thread: thread, noSeen: false)
+                    let postsPage = PostsPageViewController(thread: thread)
                     postsPage.restorationIdentifier = "Posts"
                     postsPage.loadPage(1, updatingCache: true)
                     self.showDetailViewController(postsPage, sender: self)

--- a/App/Threads/ThreadListViewController+UIViewControllerPreviewing.swift
+++ b/App/Threads/ThreadListViewController+UIViewControllerPreviewing.swift
@@ -1,0 +1,39 @@
+//
+//  ThreadListViewControllerPreview.swift
+//  Awful
+//
+//  Created by Drastic Actions on 2015/09/27.
+//  Copyright © 2015年 Awful Contributors. All rights reserved.
+//
+
+import UIKit
+
+extension ThreadListViewController : UIViewControllerPreviewingDelegate
+{
+    func previewingContext(previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
+        // Obtain the index path and the cell that was pressed.
+        guard let indexPath = tableView.indexPathForRowAtPoint(location),
+            cell = tableView.cellForRowAtIndexPath(indexPath) else { return nil }
+        
+        let thread = dataSource.itemAtIndexPath(indexPath) as! Thread
+        let postsViewController = PostsPageViewController(thread: thread)
+        postsViewController.restorationIdentifier = "Posts"
+        // SA: For an unread thread, the Forums will interpret "next unread page" to mean "last page", which is not very helpful.
+        let targetPage = thread.beenSeen ? AwfulThreadPage.NextUnread.rawValue : 1
+        postsViewController.loadPage(targetPage, updatingCache: true)
+        
+        postsViewController.preferredContentSize = CGSize(width: 0.0, height: 500)
+        
+        // Set the source rect to the cell frame, so surrounding elements are blurred.
+        previewingContext.sourceRect = cell.frame
+        
+        return postsViewController
+    }
+    
+    /// Present the view controller for the "Pop" action.
+    func previewingContext(previewingContext: UIViewControllerPreviewing, commitViewController viewControllerToCommit: UIViewController) {
+        // Reuse the "Peek" view controller for presentation.
+        showViewController(viewControllerToCommit, sender: self)
+    }
+
+}

--- a/App/Threads/ThreadListViewController+UIViewControllerPreviewing.swift
+++ b/App/Threads/ThreadListViewController+UIViewControllerPreviewing.swift
@@ -16,7 +16,7 @@ extension ThreadListViewController : UIViewControllerPreviewingDelegate
             cell = tableView.cellForRowAtIndexPath(indexPath) else { return nil }
         
         let thread = dataSource.itemAtIndexPath(indexPath) as! Thread
-        let postsViewController = PostsPageViewController(thread: thread, noSeen: true)
+        let postsViewController = PostsPageViewController(thread: thread)
         postsViewController.restorationIdentifier = "Posts"
         // SA: For an unread thread, the Forums will interpret "next unread page" to mean "last page", which is not very helpful.
         let targetPage = thread.beenSeen ? AwfulThreadPage.NextUnread.rawValue : 1

--- a/App/Threads/ThreadListViewController+UIViewControllerPreviewing.swift
+++ b/App/Threads/ThreadListViewController+UIViewControllerPreviewing.swift
@@ -20,7 +20,7 @@ extension ThreadListViewController : UIViewControllerPreviewingDelegate
         postsViewController.restorationIdentifier = "Posts"
         // SA: For an unread thread, the Forums will interpret "next unread page" to mean "last page", which is not very helpful.
         let targetPage = thread.beenSeen ? AwfulThreadPage.NextUnread.rawValue : 1
-        postsViewController.loadPage(targetPage, updatingCache: true)
+        postsViewController.loadPage(targetPage, updatingCache: true, noSeen: true)
         
         postsViewController.preferredContentSize = CGSize(width: 0.0, height: 500)
         

--- a/App/Threads/ThreadListViewController+UIViewControllerPreviewing.swift
+++ b/App/Threads/ThreadListViewController+UIViewControllerPreviewing.swift
@@ -16,7 +16,7 @@ extension ThreadListViewController : UIViewControllerPreviewingDelegate
             cell = tableView.cellForRowAtIndexPath(indexPath) else { return nil }
         
         let thread = dataSource.itemAtIndexPath(indexPath) as! Thread
-        let postsViewController = PostsPageViewController(thread: thread)
+        let postsViewController = PostsPageViewController(thread: thread, noSeen: true)
         postsViewController.restorationIdentifier = "Posts"
         // SA: For an unread thread, the Forums will interpret "next unread page" to mean "last page", which is not very helpful.
         let targetPage = thread.beenSeen ? AwfulThreadPage.NextUnread.rawValue : 1

--- a/App/Threads/ThreadListViewController.swift
+++ b/App/Threads/ThreadListViewController.swift
@@ -99,7 +99,7 @@ extension ThreadListViewController {
         postsViewController.restorationIdentifier = "Posts"
         // SA: For an unread thread, the Forums will interpret "next unread page" to mean "last page", which is not very helpful.
         let targetPage = thread.beenSeen ? AwfulThreadPage.NextUnread.rawValue : 1
-        postsViewController.loadPage(targetPage, updatingCache: true)
+        postsViewController.loadPage(targetPage, updatingCache: true, noSeen: false)
         showDetailViewController(postsViewController, sender: self)
         tableView.deselectRowAtIndexPath(indexPath, animated: true)
     }
@@ -201,7 +201,7 @@ class ThreadDataSource: FetchedDataSource {
                 let postsViewController = PostsPageViewController(thread: thread)
                 postsViewController.restorationIdentifier = "Posts"
                 let page = itemType == .JumpToLastPage ? AwfulThreadPage.Last.rawValue : 1
-                postsViewController.loadPage(page, updatingCache: true)
+                postsViewController.loadPage(page, updatingCache: true, noSeen: false)
                 viewController.showDetailViewController(postsViewController, sender: self)
             }
         }

--- a/App/Threads/ThreadListViewController.swift
+++ b/App/Threads/ThreadListViewController.swift
@@ -95,7 +95,7 @@ extension ThreadListViewController {
     
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let thread = dataSource.itemAtIndexPath(indexPath) as! Thread
-        let postsViewController = PostsPageViewController(thread: thread, noSeen: false)
+        let postsViewController = PostsPageViewController(thread: thread)
         postsViewController.restorationIdentifier = "Posts"
         // SA: For an unread thread, the Forums will interpret "next unread page" to mean "last page", which is not very helpful.
         let targetPage = thread.beenSeen ? AwfulThreadPage.NextUnread.rawValue : 1
@@ -198,7 +198,7 @@ class ThreadDataSource: FetchedDataSource {
         
         func jumpToPageItem(itemType: AwfulIconActionItemType) -> AwfulIconActionItem {
             return AwfulIconActionItem(type: itemType) {
-                let postsViewController = PostsPageViewController(thread: thread, noSeen: false)
+                let postsViewController = PostsPageViewController(thread: thread)
                 postsViewController.restorationIdentifier = "Posts"
                 let page = itemType == .JumpToLastPage ? AwfulThreadPage.Last.rawValue : 1
                 postsViewController.loadPage(page, updatingCache: true)

--- a/App/Threads/ThreadListViewController.swift
+++ b/App/Threads/ThreadListViewController.swift
@@ -40,6 +40,11 @@ class ThreadListViewController: AwfulTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // Check for force touch feature, and add force touch/previewing capability.
+        if traitCollection.forceTouchCapability == .Available {
+            registerForPreviewingWithDelegate(self, sourceView: view)
+        }
+        
         tableView.estimatedRowHeight = 75
         tableView.separatorStyle = .None
         tableView.registerNib(UINib(nibName: "ThreadCell", bundle: nil), forCellReuseIdentifier: "Thread")

--- a/App/Threads/ThreadListViewController.swift
+++ b/App/Threads/ThreadListViewController.swift
@@ -95,7 +95,7 @@ extension ThreadListViewController {
     
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let thread = dataSource.itemAtIndexPath(indexPath) as! Thread
-        let postsViewController = PostsPageViewController(thread: thread)
+        let postsViewController = PostsPageViewController(thread: thread, noSeen: false)
         postsViewController.restorationIdentifier = "Posts"
         // SA: For an unread thread, the Forums will interpret "next unread page" to mean "last page", which is not very helpful.
         let targetPage = thread.beenSeen ? AwfulThreadPage.NextUnread.rawValue : 1
@@ -198,7 +198,7 @@ class ThreadDataSource: FetchedDataSource {
         
         func jumpToPageItem(itemType: AwfulIconActionItemType) -> AwfulIconActionItem {
             return AwfulIconActionItem(type: itemType) {
-                let postsViewController = PostsPageViewController(thread: thread)
+                let postsViewController = PostsPageViewController(thread: thread, noSeen: false)
                 postsViewController.restorationIdentifier = "Posts"
                 let page = itemType == .JumpToLastPage ? AwfulThreadPage.Last.rawValue : 1
                 postsViewController.loadPage(page, updatingCache: true)

--- a/App/URLs/AwfulURLRouter.m
+++ b/App/URLs/AwfulURLRouter.m
@@ -72,7 +72,7 @@
         Post *post = [Post existingObjectForKey:key inManagedObjectContext:self.managedObjectContext];
         if (post && post.page > 0) {
             PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread];
-            [postsViewController loadPage:post.page updatingCache:YES];
+            [postsViewController loadPage:post.page updatingCache:YES noSeen:NO];
             [postsViewController scrollPostToVisible:post];
             return [self showPostsViewController:postsViewController];
         }
@@ -94,7 +94,7 @@
             } else {
                 [overlay dismiss:YES completion:^{
                     PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread];
-                    [postsViewController loadPage:page updatingCache:YES];
+                    [postsViewController loadPage:page updatingCache:YES noSeen:NO];
                     [postsViewController scrollPostToVisible:post];
                     [self showPostsViewController:postsViewController];
                     NSError *error;
@@ -284,7 +284,7 @@
     if (page == AwfulThreadPageNone) {
         page = pageString.integerValue ?: thread.beenSeen ? AwfulThreadPageNextUnread : 1;
     }
-    [postsViewController loadPage:page updatingCache:YES];
+    [postsViewController loadPage:page updatingCache:YES noSeen:NO];
     if (parameters[@"post"]) {
         PostKey *postKey = [[PostKey alloc] initWithPostID:parameters[@"post"]];
         [postsViewController scrollPostToVisible:[Post objectForKey:postKey inManagedObjectContext:self.managedObjectContext]];

--- a/App/URLs/AwfulURLRouter.m
+++ b/App/URLs/AwfulURLRouter.m
@@ -71,7 +71,7 @@
         PostKey *key = [[PostKey alloc] initWithPostID:parameters[@"postID"]];
         Post *post = [Post existingObjectForKey:key inManagedObjectContext:self.managedObjectContext];
         if (post && post.page > 0) {
-            PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread];
+            PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread noSeen:NO];
             [postsViewController loadPage:post.page updatingCache:YES];
             [postsViewController scrollPostToVisible:post];
             return [self showPostsViewController:postsViewController];
@@ -93,7 +93,7 @@
                 });
             } else {
                 [overlay dismiss:YES completion:^{
-                    PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread];
+                    PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread noSeen: NO];
                     [postsViewController loadPage:page updatingCache:YES];
                     [postsViewController scrollPostToVisible:post];
                     [self showPostsViewController:postsViewController];
@@ -266,7 +266,7 @@
         User *user = [User objectForKey:userKey inManagedObjectContext:self.managedObjectContext];
         postsViewController = [[PostsPageViewController alloc] initWithThread:thread author:user];
     } else {
-        postsViewController = [[PostsPageViewController alloc] initWithThread:thread];
+        postsViewController = [[PostsPageViewController alloc] initWithThread:thread noSeen: NO];
     }
     NSError *error;
     if (![self.managedObjectContext save:&error]) {

--- a/App/URLs/AwfulURLRouter.m
+++ b/App/URLs/AwfulURLRouter.m
@@ -71,7 +71,7 @@
         PostKey *key = [[PostKey alloc] initWithPostID:parameters[@"postID"]];
         Post *post = [Post existingObjectForKey:key inManagedObjectContext:self.managedObjectContext];
         if (post && post.page > 0) {
-            PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread noSeen:NO];
+            PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread];
             [postsViewController loadPage:post.page updatingCache:YES];
             [postsViewController scrollPostToVisible:post];
             return [self showPostsViewController:postsViewController];
@@ -93,7 +93,7 @@
                 });
             } else {
                 [overlay dismiss:YES completion:^{
-                    PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread noSeen: NO];
+                    PostsPageViewController *postsViewController = [[PostsPageViewController alloc] initWithThread:post.thread];
                     [postsViewController loadPage:page updatingCache:YES];
                     [postsViewController scrollPostToVisible:post];
                     [self showPostsViewController:postsViewController];
@@ -266,7 +266,7 @@
         User *user = [User objectForKey:userKey inManagedObjectContext:self.managedObjectContext];
         postsViewController = [[PostsPageViewController alloc] initWithThread:thread author:user];
     } else {
-        postsViewController = [[PostsPageViewController alloc] initWithThread:thread noSeen: NO];
+        postsViewController = [[PostsPageViewController alloc] initWithThread:thread];
     }
     NSError *error;
     if (![self.managedObjectContext save:&error]) {

--- a/Awful.xcworkspace/xcshareddata/Awful.xcscmblueprint
+++ b/Awful.xcworkspace/xcshareddata/Awful.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "A6E2134366602D593993B263D3DBDCD59EEAAA4E",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "A6E2134366602D593993B263D3DBDCD59EEAAA4E" : 0,
+    "A563C6B0F1E6EB470BEDBBD2A36B40C1F3CC113D" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "ACBED1E3-08B9-4AFB-B510-1808BAC09E9E",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "A6E2134366602D593993B263D3DBDCD59EEAAA4E" : "AwfulApp\/",
+    "A563C6B0F1E6EB470BEDBBD2A36B40C1F3CC113D" : "AwfulApp\/Resources\/Thread%20Tags\/"
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "Awful",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Awful.xcworkspace",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/Awful\/thread-tags",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "A563C6B0F1E6EB470BEDBBD2A36B40C1F3CC113D"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/drasticactions\/Awful.app.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "A6E2134366602D593993B263D3DBDCD59EEAAA4E"
+    }
+  ]
+}

--- a/Core/Networking/AwfulForumsClient.h
+++ b/Core/Networking/AwfulForumsClient.h
@@ -175,6 +175,7 @@
 - (NSOperation *)listPostsInThread:(Thread *)thread
                          writtenBy:(User *)author
                             onPage:(AwfulThreadPage)page
+                            noSeen:(bool)notSeen
                            andThen:(void (^)(NSError *error, NSArray *posts, NSUInteger firstUnreadPost, NSString *advertisementHTML))callback;
 
 /**

--- a/Core/Networking/AwfulForumsClient.h
+++ b/Core/Networking/AwfulForumsClient.h
@@ -175,7 +175,6 @@
 - (NSOperation *)listPostsInThread:(Thread *)thread
                          writtenBy:(User *)author
                             onPage:(AwfulThreadPage)page
-                            noSeen:(bool)notSeen
                            andThen:(void (^)(NSError *error, NSArray *posts, NSUInteger firstUnreadPost, NSString *advertisementHTML))callback;
 
 /**

--- a/Core/Networking/AwfulForumsClient.h
+++ b/Core/Networking/AwfulForumsClient.h
@@ -25,9 +25,9 @@
 + (instancetype)sharedClient;
 
 /**
-    The Forums endpoint for the client. Typically http://forums.somethingawful.com
+ The Forums endpoint for the client. Typically http://forums.somethingawful.com
  
-    Setting a new baseURL cancels all in-flight requests.
+ Setting a new baseURL cancels all in-flight requests.
  */
 @property (strong, nonatomic) NSURL *baseURL;
 
@@ -175,6 +175,7 @@
 - (NSOperation *)listPostsInThread:(Thread *)thread
                          writtenBy:(User *)author
                             onPage:(AwfulThreadPage)page
+                            noSeen:(bool)notSeen
                            andThen:(void (^)(NSError *error, NSArray *posts, NSUInteger firstUnreadPost, NSString *advertisementHTML))callback;
 
 /**

--- a/Core/Networking/AwfulForumsClient.m
+++ b/Core/Networking/AwfulForumsClient.m
@@ -541,6 +541,7 @@
 - (NSOperation *)listPostsInThread:(Thread *)thread
                          writtenBy:(User *)author
                             onPage:(AwfulThreadPage)page
+                           noSeen:(bool)notSeen
                            andThen:(void (^)(NSError *error, NSArray *posts, NSUInteger firstUnreadPost, NSString *advertisementHTML))callback
 {
     NSMutableDictionary *parameters = [@{ @"threadid": thread.threadID,
@@ -551,6 +552,10 @@
         parameters[@"goto"] = @"lastpost";
     } else {
         parameters[@"pagenumber"] = @(page);
+    }
+    if(notSeen)
+    {
+        parameters[@"noseen"] = @"1";
     }
     if (author.userID) {
         parameters[@"userid"] = author.userID;

--- a/Core/Networking/AwfulForumsClient.m
+++ b/Core/Networking/AwfulForumsClient.m
@@ -541,6 +541,7 @@
 - (NSOperation *)listPostsInThread:(Thread *)thread
                          writtenBy:(User *)author
                             onPage:(AwfulThreadPage)page
+                            noSeen:(bool)notSeen
                            andThen:(void (^)(NSError *error, NSArray *posts, NSUInteger firstUnreadPost, NSString *advertisementHTML))callback
 {
     NSMutableDictionary *parameters = [@{ @"threadid": thread.threadID,
@@ -551,6 +552,10 @@
         parameters[@"goto"] = @"lastpost";
     } else {
         parameters[@"pagenumber"] = @(page);
+    }
+    if(notSeen)
+    {
+        parameters[@"noseen"] = @"1";
     }
     if (author.userID) {
         parameters[@"userid"] = author.userID;

--- a/Core/Networking/AwfulForumsClient.m
+++ b/Core/Networking/AwfulForumsClient.m
@@ -541,7 +541,6 @@
 - (NSOperation *)listPostsInThread:(Thread *)thread
                          writtenBy:(User *)author
                             onPage:(AwfulThreadPage)page
-                           noSeen:(bool)notSeen
                            andThen:(void (^)(NSError *error, NSArray *posts, NSUInteger firstUnreadPost, NSString *advertisementHTML))callback
 {
     NSMutableDictionary *parameters = [@{ @"threadid": thread.threadID,
@@ -552,10 +551,6 @@
         parameters[@"goto"] = @"lastpost";
     } else {
         parameters[@"pagenumber"] = @(page);
-    }
-    if(notSeen)
-    {
-        parameters[@"noseen"] = @"1";
     }
     if (author.userID) {
         parameters[@"userid"] = author.userID;

--- a/Xcode/Awful.xcodeproj/project.pbxproj
+++ b/Xcode/Awful.xcodeproj/project.pbxproj
@@ -322,6 +322,7 @@
 		1CEB5BFF19AB9C1700C82C30 /* InAppActionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CEB5BFE19AB9C1700C82C30 /* InAppActionViewController.swift */; };
 		1CF186A617D48E5700B26717 /* Thread Tags in Resources */ = {isa = PBXBuildFile; fileRef = 1CF186A517D48E5700B26717 /* Thread Tags */; };
 		1CF3A467180C768100EC2450 /* AwfulURLRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CF3A466180C768100EC2450 /* AwfulURLRouter.m */; };
+		3A17B62C1BB83D73009D54E3 /* ThreadListViewController+UIViewControllerPreviewing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A17B62B1BB83D73009D54E3 /* ThreadListViewController+UIViewControllerPreviewing.swift */; };
 		83410EF219A582B8002CD019 /* DateFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83410EF119A582B8002CD019 /* DateFormatters.swift */; };
 		837D67EE1861C25000464055 /* ForumTweaks.plist in Resources */ = {isa = PBXBuildFile; fileRef = 837D67ED1861C25000464055 /* ForumTweaks.plist */; };
 		837D67F11861C3D700464055 /* AwfulForumTweaks.m in Sources */ = {isa = PBXBuildFile; fileRef = 837D67F01861C3D700464055 /* AwfulForumTweaks.m */; };
@@ -876,6 +877,7 @@
 		1CFE985B18297255003DBBC2 /* AwfulScanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AwfulScanner.h; sourceTree = "<group>"; };
 		1CFE985C18297255003DBBC2 /* AwfulScanner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AwfulScanner.m; sourceTree = "<group>"; };
 		1D6058910D05DD3D006BFB54 /* Awful Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Awful Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A17B62B1BB83D73009D54E3 /* ThreadListViewController+UIViewControllerPreviewing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ThreadListViewController+UIViewControllerPreviewing.swift"; sourceTree = "<group>"; };
 		3DEC84CD16F06A21949AA42D /* Pods-Awful.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Awful.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Awful/Pods-Awful.debug.xcconfig"; sourceTree = "<group>"; };
 		68A40BB24850D9A942D1E270 /* Pods_Awful.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Awful.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7846FF6DDA37B81D34DE2AE5 /* Pods-Core.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Core.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Core/Pods-Core.release.xcconfig"; sourceTree = "<group>"; };
@@ -1610,6 +1612,7 @@
 				1C9381C4181A95EC00258191 /* ThreadComposeViewController.h */,
 				1C9381C5181A95EC00258191 /* ThreadComposeViewController.m */,
 				1CA86BD51A370FD300103C1C /* ThreadListViewController.swift */,
+				3A17B62B1BB83D73009D54E3 /* ThreadListViewController+UIViewControllerPreviewing.swift */,
 			);
 			path = Threads;
 			sourceTree = "<group>";
@@ -2011,6 +2014,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = "";
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Awful Contributors";
 				TargetAttributes = {
@@ -2034,6 +2038,7 @@
 					};
 					1C66A9EE19DD3939001B9A41 = {
 						CreatedOnToolsVersion = 6.0.1;
+						DevelopmentTeam = Z2DGZL23AH;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
@@ -2041,6 +2046,7 @@
 						};
 					};
 					1D6058900D05DD3D006BFB54 = {
+						DevelopmentTeam = Z2DGZL23AH;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
@@ -2526,6 +2532,7 @@
 				1C09963C16C0AECA00A62D5E /* AwfulPunishmentCell.m in Sources */,
 				1CA86BDA1A380B5E00103C1C /* ForumSpecificThreadListViewController.swift in Sources */,
 				1CEB5BFF19AB9C1700C82C30 /* InAppActionViewController.swift in Sources */,
+				3A17B62C1BB83D73009D54E3 /* ThreadListViewController+UIViewControllerPreviewing.swift in Sources */,
 				1C26BFE01818E56F00E55887 /* ComposeTextViewController.m in Sources */,
 				1C7C60BF18FCA01E009BF4BB /* PrivateMessageViewModel.m in Sources */,
 				1C8F0DE5191CF89D00CE8DEE /* AwfulJavaScript.m in Sources */,
@@ -3030,6 +3037,8 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CODE_SIGN_ENTITLEMENTS = ../Smilies/Keyboard/Keyboard.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -3050,6 +3059,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.awfulapp.Awful$(AWFUL_BUNDLE_ID_SUFFIX).SmilieKeyboard";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -3072,6 +3082,8 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_ENTITLEMENTS = ../Smilies/Keyboard/Keyboard.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -3087,6 +3099,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.awfulapp.Awful$(AWFUL_BUNDLE_ID_SUFFIX).SmilieKeyboard";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				VALIDATE_PRODUCT = YES;
@@ -3102,6 +3115,8 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_ENTITLEMENTS = ../App/Awful.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COMPRESS_PNG_FILES = NO;
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3115,6 +3130,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.awfulapp.Awful${AWFUL_BUNDLE_ID_SUFFIX}";
 				PRODUCT_MODULE_NAME = Awful;
 				PRODUCT_NAME = "Awful${AWFUL_BUNDLE_DISPLAY_NAME_SUFFIX}";
+				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "../App/Main/Awful-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3129,6 +3145,8 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_ENTITLEMENTS = ../App/Awful.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COMPRESS_PNG_FILES = NO;
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3145,6 +3163,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.awfulapp.Awful${AWFUL_BUNDLE_ID_SUFFIX}";
 				PRODUCT_MODULE_NAME = Awful;
 				PRODUCT_NAME = "Awful${AWFUL_BUNDLE_DISPLAY_NAME_SUFFIX}";
+				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "../App/Main/Awful-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
Note: this is the same as my other PR, but this time it's from a feature branch, because I was dumb and didn't realize I put this in my master branch. But otherwise this should get you peek and pop functionality in thread list views, and it should not change the state of the thread in any way.

This PR should give you a (very much hacked together!) 3D Touch peek and pop function for threads. So you can 3D touch a thread in the thread list or bookmarks to get a peek at the thread, then hold down to pop the thread open.

I'm not that familiar with Swift, nor with how the codebase is laid out. So I hope I did it right.

![Peek Thread](http://i.imgur.com/5mNL7Pt.jpg)