### PR TITLE
fix build when CRASHLYTICS_API_KEY is not set

### DIFF
--- a/Xcode/Awful.xcodeproj/project.pbxproj
+++ b/Xcode/Awful.xcodeproj/project.pbxproj
@@ -3060,7 +3060,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "[[ \"$CRASHLYTICS_API_KEY\" ]] && \"$PODS_ROOT\"/Fabric/run \"$CRASHLYTICS_API_KEY\"\n";
+			shellScript = "if [ -n \"$CRASHLYTICS_API_KEY\" ]; then \"$PODS_ROOT\"/Fabric/run \"$CRASHLYTICS_API_KEY\"; fi";
 		};
 		1C8F0DE6191CFA2200CE8DEE /* Compile CSS */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
The current crashlytics step will fail the build if an API key isn't
configured. Crashlytics isn't necessary for most development, so
switching to a form that doesn't barf.

Ran xcode builds before/after; verified it now works on a completely
fresh checkout.

Before:
```
$ [[ "$CRASHLYTICS_API_KEY" ]] && "$PODS_ROOT"/Fabric/run "$CRASHLYTICS_API_KEY"; echo $?
1
```

After:
```
$ if [ -n "$CRASHLYTICS_API_KEY" ]; then "$PODS_ROOT"/Fabric/run "$CRASHLYTICS_API_KEY"; fi; echo $?
0
```