### PR TITLE
move html parsing off of the main thread

### DIFF
--- a/Core/Networking/ForumsClient.swift
+++ b/Core/Networking/ForumsClient.swift
@@ -1305,7 +1305,7 @@ private extension Promise {
 
 private extension Promise where T == (data: Data, response: URLResponse) {
     func scrape<U: ScrapeResult>(as _: U.Type) -> Promise<U> {
-        return map {
+        return map(on: .global()) {
             let parsed = try parseHTML(data: $0.data, response: $0.response)
             return try U.init(parsed.document, url: parsed.url)
         }


### PR DESCRIPTION
Noticed some of the html parsing was still running on the main thread, occasionally taking 400+ milliseconds.

This seemed like the easiest way to move it off - but we could also default all the map/thens to running on a background queue via Promiskit's conf, or rewrite scrape to scrape(on:as: ) and update callsites.

Any particular preference, or something I'm missing about why this can't/shouldn't be moved?