### PR TITLE
Settings does not update when selecting default browser

### DIFF
--- a/App/Settings/SettingsViewController.swift
+++ b/App/Settings/SettingsViewController.swift
@@ -130,6 +130,12 @@ final class SettingsViewController: TableViewController {
         refreshIfNecessary()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        tableView.reloadData()
+    }
+    
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         Log.d("hello")


### PR DESCRIPTION
A (probably naive) attempt at fixing a bug I came across where changing the default browser failed to update the settings panel until the table cell was moved off screen. I'm not an ios dev, so feel free to tell me what I did is completely bad/wrong.

![awfulappbug](https://user-images.githubusercontent.com/1863450/44621454-4b6a6b80-a86c-11e8-84c3-622df2f43f1c.gif)
