### PR TITLE
correct the color of :ins: smiley when using amberpos theme

### DIFF
--- a/App/Theming/posts-view-amberpos.css
+++ b/App/Theming/posts-view-amberpos.css
@@ -460,6 +460,10 @@ post.seen {
 [title~=":yohoho:"] {
   -webkit-filter: invert(100%);
 }
+[title~=":ins:"] {
+    content: url('data:image/gif;base64,R0lGODlhBgAOAIABAOrPTP///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQJMgABACwAAAAABgAOAAACCoyPqcvtr4CcVBYAIfkEBTIAAQAsAAAAAAYADgAAAgiMj6nL7Q9VAQA7');
+}
+
 .postbody {
   letter-spacing: -0.01em;
   line-height: 1.18em;


### PR DESCRIPTION
#757 
Since there isn't a clean way to re-color a green smiley, I just replaced it with a amber one using a data URI.
![image](https://user-images.githubusercontent.com/1863450/44622573-93938900-a880-11e8-89ff-76c1ba362ecb.png)