### PR TITLE
Add "Own Posts" finder to Posts view menu

### DIFF
--- a/App/In-App Actions/IconActionItem.swift
+++ b/App/In-App Actions/IconActionItem.swift
@@ -38,6 +38,7 @@ final class IconActionItem: NSObject {
     case jumpToLastPage
     case markAsUnread
     case markReadUpToHere
+    case ownPosts
     case quotePost
     case rapSheet
     case removeBookmark
@@ -60,6 +61,7 @@ final class IconActionItem: NSObject {
         case .jumpToLastPage: return "Last Page"
         case .markAsUnread: return "Mark Unread"
         case .markReadUpToHere: return "Mark Read"
+        case .ownPosts: return "Your Posts"
         case .quotePost: return "Quote"
         case .rapSheet: return "Rap Sheet"
         case .reportPost: return "Report"
@@ -84,6 +86,7 @@ final class IconActionItem: NSObject {
         case .jumpToLastPage: return "jump-to-last-page"
         case .markAsUnread: return "mark-as-unread"
         case .markReadUpToHere: return "mark-read-up-to-here"
+        case .ownPosts: return "single-users-posts"
         case .quotePost: return "quote-post"
         case .rapSheet: return "rap-sheet"
         case .reportPost: return "rap-sheet"
@@ -108,6 +111,7 @@ final class IconActionItem: NSObject {
         case .jumpToLastPage: return "jumpToLastPageIconColor"
         case .markAsUnread: return "markUnreadIconColor"
         case .markReadUpToHere: return "markReadUpToHereIconColor"
+        case .ownPosts: return "singleUserIconColor"
         case .quotePost: return "quoteIconColor"
         case .rapSheet: return "rapSheetIconColor"
         case .reportPost: return "rapSheetIconColor"

--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -407,7 +407,12 @@ final class PostsPageViewController: ViewController {
             actionVC.title = self.title
 
             let ownPostsItem = IconActionItem(.ownPosts, block: {
-                
+                let userKey = UserKey(userID: UserDefaults.standard.loggedInUserID!, username: UserDefaults.standard.loggedInUsername)
+                let user = User.objectForKey(objectKey: userKey, inManagedObjectContext: self.thread.managedObjectContext!) as! User
+                let postsVC = PostsPageViewController(thread: self.thread, author: user)
+                postsVC.restorationIdentifier = "Just your posts"
+                postsVC.loadPage(.first, updatingCache: true, updatingLastReadPost: true)
+                self.navigationController?.pushViewController(postsVC, animated: true)
             })
             ownPostsItem.title = "Your Posts"
             

--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -406,17 +406,7 @@ final class PostsPageViewController: ViewController {
             let actionVC = InAppActionViewController()
             actionVC.title = self.title
 
-            let ownPostsItem = IconActionItem(.ownPosts, block: {
-                let userKey = UserKey(userID: UserDefaults.standard.loggedInUserID!, username: UserDefaults.standard.loggedInUsername)
-                let user = User.objectForKey(objectKey: userKey, inManagedObjectContext: self.thread.managedObjectContext!) as! User
-                let postsVC = PostsPageViewController(thread: self.thread, author: user)
-                postsVC.restorationIdentifier = "Just your posts"
-                postsVC.loadPage(.first, updatingCache: true, updatingLastReadPost: true)
-                self.navigationController?.pushViewController(postsVC, animated: true)
-            })
-            ownPostsItem.title = "Your Posts"
-            
-            let copyURLItem = IconActionItem(.copyURL, block: { 
+            let copyURLItem = IconActionItem(.copyURL, block: {
                 let components = NSURLComponents(string: "https://forums.somethingawful.com/showthread.php")!
                 var queryItems = [
                     URLQueryItem(name: "threadid", value: self.thread.threadID),
@@ -483,7 +473,21 @@ final class PostsPageViewController: ViewController {
                 }
             })
             
-            actionVC.items = [copyURLItem, ownPostsItem, voteItem, bookmarkItem]
+            if let author = self.author {
+                actionVC.items = [copyURLItem, voteItem, bookmarkItem]
+            } else {
+                let ownPostsItem = IconActionItem(.ownPosts, block: {
+                    let userKey = UserKey(userID: UserDefaults.standard.loggedInUserID!, username: UserDefaults.standard.loggedInUsername)
+                    let user = User.objectForKey(objectKey: userKey, inManagedObjectContext: self.thread.managedObjectContext!) as! User
+                    let postsVC = PostsPageViewController(thread: self.thread, author: user)
+                    postsVC.restorationIdentifier = "Just your posts"
+                    postsVC.loadPage(.first, updatingCache: true, updatingLastReadPost: true)
+                    self.navigationController?.pushViewController(postsVC, animated: true)
+                })
+                ownPostsItem.title = "Your Posts"
+
+                actionVC.items = [copyURLItem, ownPostsItem, voteItem, bookmarkItem]
+            }
             self.present(actionVC, animated: true, completion: nil)
             
             if let popover = actionVC.popoverPresentationController {

--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -405,6 +405,11 @@ final class PostsPageViewController: ViewController {
         item.actionBlock = { [unowned self] (sender) in
             let actionVC = InAppActionViewController()
             actionVC.title = self.title
+
+            let ownPostsItem = IconActionItem(.ownPosts, block: {
+                
+            })
+            ownPostsItem.title = "Your Posts"
             
             let copyURLItem = IconActionItem(.copyURL, block: { 
                 let components = NSURLComponents(string: "https://forums.somethingawful.com/showthread.php")!
@@ -473,7 +478,7 @@ final class PostsPageViewController: ViewController {
                 }
             })
             
-            actionVC.items = [copyURLItem, voteItem, bookmarkItem]
+            actionVC.items = [copyURLItem, ownPostsItem, voteItem, bookmarkItem]
             self.present(actionVC, animated: true, completion: nil)
             
             if let popover = actionVC.popoverPresentationController {


### PR DESCRIPTION
Earlier this week I posted in a thread to find my own posts, because search wasn't working for it. I was shamed, appropriately, and so I'm adding this to help myself and others in the future.

My first Swift! Please be picky about style and practices, I'll fix it up!

Thought: change "All Posts" in the per-post menu in author-narrowed view to "Find Post" to distinguish it better from what you get when you just go <Back? Happy to ride it along here if you agree.