### PR TITLE
Added "Cancel" menu item on New Reply > Cancel.

### DIFF
--- a/App/Posts/ReplyWorkspace.swift
+++ b/App/Posts/ReplyWorkspace.swift
@@ -171,17 +171,17 @@ final class ReplyWorkspace: NSObject {
             message: nil,
             preferredStyle: .actionSheet)
         actionSheet.addAction(.init(
-            title: NSLocalizedString("compose.cancel-menu.save-draft", comment: ""),
-            style: .default,
-            handler: { action in
-                self.completion(.saveDraft)
-            }
-        ))
-        actionSheet.addAction(.init(
             title: NSLocalizedString("compose.cancel-menu.delete-draft", comment: ""),
             style: .destructive,
             handler: { action in
                 self.completion(.forgetAboutIt)
+            }
+        ))
+        actionSheet.addAction(.init(
+            title: NSLocalizedString("compose.cancel-menu.save-draft", comment: ""),
+            style: .default,
+            handler: { action in
+                self.completion(.saveDraft)
             }
         ))
         actionSheet.addCancelActionWithHandler(nil)

--- a/App/Posts/ReplyWorkspace.swift
+++ b/App/Posts/ReplyWorkspace.swift
@@ -171,6 +171,13 @@ final class ReplyWorkspace: NSObject {
             message: nil,
             preferredStyle: .actionSheet)
         actionSheet.addAction(.init(
+            title: NSLocalizedString("compose.cancel-menu.continue-replying", comment: ""),
+            style: .default,
+            handler: { action in
+                actionSheet.dismiss(animated: true, completion: nil)
+            }
+        ))
+        actionSheet.addAction(.init(
             title: NSLocalizedString("compose.cancel-menu.save-draft", comment: ""),
             style: .default,
             handler: { action in

--- a/App/Posts/ReplyWorkspace.swift
+++ b/App/Posts/ReplyWorkspace.swift
@@ -171,13 +171,6 @@ final class ReplyWorkspace: NSObject {
             message: nil,
             preferredStyle: .actionSheet)
         actionSheet.addAction(.init(
-            title: NSLocalizedString("compose.cancel-menu.continue-replying", comment: ""),
-            style: .default,
-            handler: { action in
-                actionSheet.dismiss(animated: true, completion: nil)
-            }
-        ))
-        actionSheet.addAction(.init(
             title: NSLocalizedString("compose.cancel-menu.save-draft", comment: ""),
             style: .default,
             handler: { action in
@@ -191,6 +184,7 @@ final class ReplyWorkspace: NSObject {
                 self.completion(.forgetAboutIt)
             }
         ))
+        actionSheet.addCancelActionWithHandler(nil)
         compositionViewController.present(actionSheet, animated: true)
 
         if let popover = actionSheet.popoverPresentationController {

--- a/App/Resources/Localizable.strings
+++ b/App/Resources/Localizable.strings
@@ -196,6 +196,7 @@
 /* Destructive button in action sheet that deletes the draft. */
 "compose.cancel-menu.delete-draft" = "Delete Draft";
 
+
 /* MARK: Compose thread */
 
 /* Text shown below the title of the thread-to-be. Parameter is the name of the forum where this will be posted. */

--- a/App/Resources/Localizable.strings
+++ b/App/Resources/Localizable.strings
@@ -195,8 +195,6 @@
 "compose.cancel-menu.save-draft" = "Save Draft";
 /* Destructive button in action sheet that deletes the draft. */
 "compose.cancel-menu.delete-draft" = "Delete Draft";
-/* Button in action sheet that resumes the draft reply. */
-"compose.cancel-menu.continue-replying" = "Continue Replying";
 
 /* MARK: Compose thread */
 

--- a/App/Resources/Localizable.strings
+++ b/App/Resources/Localizable.strings
@@ -195,7 +195,8 @@
 "compose.cancel-menu.save-draft" = "Save Draft";
 /* Destructive button in action sheet that deletes the draft. */
 "compose.cancel-menu.delete-draft" = "Delete Draft";
-
+/* Button in action sheet that resumes the draft reply. */
+"compose.cancel-menu.continue-replying" = "Continue Replying";
 
 /* MARK: Compose thread */
 

--- a/App/Resources/Localizable.strings
+++ b/App/Resources/Localizable.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   Localizable.strings
 
   Copyright 2017 Awful Contributors. CC BY-NC-SA 3.0 US https://github.com/Awful/Awful.app


### PR DESCRIPTION
Reported: https://forums.somethingawful.com/showthread.php?threadid=3837546&pagenumber=96#post512429055

While getting that link for my commit message, I see that The Dave has advised that a swipe down from top dismisses the alert. 

I wasn't aware of that, so doing a PR anyway. Cancel if need be :)

P.S. I did consider using addCancelActionWithHandler(nil), but I preferred the look and behaviour of this.
Also, I did consider re-using the existing Localizable.strings, but figured I'd just duplicate it for compose.cancel-menu 