### PR TITLE
Author action menu now listens on Avatar and Username rather than whole header

### DIFF
--- a/App/Resources/RenderView.js
+++ b/App/Resources/RenderView.js
@@ -191,13 +191,13 @@ Awful.handleClickEvent = function(event) {
     return;
   }
 
-  // Tap on post header to reveal actions on the poster.
-  var header = event.target.closest('header');
+  // Tap on poster's username or avatar to reveal actions on the poster.
+  var usernameOrAvatar = event.target.closest('.username, .avatar');
   var didTapAuthorHandler = window.webkit.messageHandlers.didTapAuthorHeader;
-  if (header && didTapAuthorHandler) {
-    var postIndex = Awful.postIndexOfElement(header);
+  if (usernameOrAvatar && didTapAuthorHandler) {
+    var postIndex = Awful.postIndexOfElement(usernameOrAvatar);
     if (postIndex !== null) {
-      var frame = Awful.frameOfElement(header);
+      var frame = Awful.frameOfElement(usernameOrAvatar);
       didTapAuthorHandler.postMessage({
           "frame": frame,
           "postIndex": postIndex


### PR DESCRIPTION
"Can we make just the user name act as a button rather than the whole space horizontally to the right? I’m currently double tapping in that blank space and it brings up the menu instead of jumping."

https://forums.somethingawful.com/showthread.php?threadid=3837546&pagenumber=97#post512466984

Fix: Yes we can. Made the avatar trigger the options also. Long press on avatar still works as before