### PR TITLE
No more duplicate smilies on the keyboard

### DIFF
--- a/Smilies/Sources/Smilies/SmilieOperation.m
+++ b/Smilies/Sources/Smilies/SmilieOperation.m
@@ -380,20 +380,20 @@ void UpdateSmilieImageDataDerivedAttributes(Smilie *smilie)
     
     NSMutableArray *newTexts = [NSMutableArray new];
     {{
-        NSUInteger scrapedIndex = 0, knownIndex = 0;
-        for (; scrapedIndex < scrapedTexts.count && knownIndex < knownTexts.count; scrapedIndex++) {
-            NSString *scraped = scrapedTexts[scrapedIndex];
+        NSUInteger knownIndex = 0;
+        
+        for (; knownIndex < knownTexts.count ; knownIndex++) {
             NSString *known = knownTexts[knownIndex];
-            if ([scraped isEqualToString:known]) {
-                knownIndex++;
-            } else {
-                [newTexts addObject:scraped];
+            NSUInteger matchIndex = [scrapedTexts indexOfObject:known];
+            
+            if (matchIndex >= 0 && matchIndex < scrapedTexts.count){
+                [scrapedTexts removeObjectAtIndex:matchIndex];
             }
         }
-        [newTexts addObjectsFromArray:[scrapedTexts subarrayWithRange:NSMakeRange(scrapedIndex, scrapedTexts.count - scrapedIndex)]];
+ 
     }}
     
-    if (newTexts.count == 0 || self.cancelled) return;
+    if (scrapedTexts.count == 0 || self.cancelled) return;
     
     [self.context performBlockAndWait:^{
         [headers enumerateObjectsUsingBlock:^(HTMLElement *header, NSUInteger i, BOOL *stop) {
@@ -402,7 +402,7 @@ void UpdateSmilieImageDataDerivedAttributes(Smilie *smilie)
             HTMLElement *section = lists[i];
             for (HTMLElement *item in [section nodesMatchingSelector:@"li"]) {
                 NSString *text = [item firstNodeMatchingSelector:@".text"].textContent;
-                if (![newTexts containsObject:text]) continue;
+                if (![scrapedTexts containsObject:text]) continue;
                 
                 Smilie *smilie = [Smilie newInManagedObjectContext:self.context];
                 smilie.text = text;


### PR DESCRIPTION
There was an issue with the original loop and matching the smilie text values. 
For some reason scraped isEqualToString:known wasn't detecting matches.

Changed it so that the known array loops once and checks scrapedTexts for a match (if an index exists). If a match is found, I remove the object from scrapedTexts using that index value.

Then I pass scrapedTexts to the next bit, rather than newTexts.