### PR TITLE
New option "Copy post" for closed threads

### DIFF
--- a/App/In-App Actions/IconActionItem.swift
+++ b/App/In-App Actions/IconActionItem.swift
@@ -40,6 +40,7 @@ final class IconActionItem: NSObject {
     case markReadUpToHere
     case ownPosts
     case quotePost
+    case copyPost
     case rapSheet
     case removeBookmark
     case reportPost
@@ -63,6 +64,7 @@ final class IconActionItem: NSObject {
         case .markReadUpToHere: return "Mark Read"
         case .ownPosts: return "Your Posts"
         case .quotePost: return "Quote"
+        case .copyPost: return "Copy Post"
         case .rapSheet: return "Rap Sheet"
         case .reportPost: return "Report"
         case .removeBookmark: return "Unmark"
@@ -88,6 +90,7 @@ final class IconActionItem: NSObject {
         case .markReadUpToHere: return "mark-read-up-to-here"
         case .ownPosts: return "single-users-posts"
         case .quotePost: return "quote-post"
+        case .copyPost: return "quote-post"
         case .rapSheet: return "rap-sheet"
         case .reportPost: return "rap-sheet"
         case .removeBookmark: return "remove-bookmark"
@@ -113,6 +116,7 @@ final class IconActionItem: NSObject {
         case .markReadUpToHere: return "markReadUpToHereIconColor"
         case .ownPosts: return "singleUserIconColor"
         case .quotePost: return "quoteIconColor"
+        case .copyPost: return "quoteIconColor"
         case .rapSheet: return "rapSheetIconColor"
         case .reportPost: return "rapSheetIconColor"
         case .removeBookmark: return "removeBookmarkIconColor"

--- a/App/Resources/Localizable.strings
+++ b/App/Resources/Localizable.strings
@@ -129,6 +129,14 @@
 /* Button that jumps to the bottom of the page. */
 "posts-page.scroll-to-end-button.accessibility-label" = "Scroll to end";
 
+/* Title of alert shown when post successfully copied to pasteboard. */
+"posts-page.copied-post" = "Copied post!";
+
+/* Title of alert shown when failing to copy post to pasteboard. */
+"posts-page.error.could-not-copy-post" = "Could not copy post";
+
+/* Title of alert shown when failing to edit post. */
+"posts-page.error.could-not-edit-post" = "Could Not Edit Post";
 
 /* MARK: Rap sheet */
 

--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -637,7 +637,7 @@ final class PostsPageViewController: ViewController {
             }
         }()
         
-        composeItem.isEnabled = !thread.closed
+        composeItem.isEnabled = !thread.closed && thread.forum?.canPost == true
     }
     
     private func showLoadingView() {
@@ -1018,31 +1018,25 @@ final class PostsPageViewController: ViewController {
             }))
         } else {
             items.append(IconActionItem(.copyPost, block: {
-                func copyPost(_ post: Post) {
-                    let overlay = MRProgressOverlayView.showOverlayAdded(to: self.postsView.renderView,
-                                                                         title: LocalizedString("posts-page.copied-post"),
-                                                                         mode: .checkmark,
-                                                                         animated: true)
-                    overlay?.tintColor = self.theme["tintColor"]
-                 
-                    ForumsClient.shared.quoteBBcodeContents(of: post)
-                        .done { [weak self] bbcode in
-                            guard self != nil else { return }
-                            UIPasteboard.general.string = bbcode
-                        }
-                        .catch { [weak self] error in
-                            guard let self = self else { return }
-                            let alert = UIAlertController(title: LocalizedString("posts-page.error.could-not-copy-post"), error: error)
-                            self.present(alert, animated: true)
-                        }
-                        .finally {
-                            DispatchQueue.main.async {
-                                overlay?.dismiss(true)
-                            }
-                        }
-                }
+                let overlay = MRProgressOverlayView.showOverlayAdded(to: self.postsView.renderView,
+                                                                     title: LocalizedString("posts-page.copied-post"),
+                                                                     mode: .checkmark,
+                                                                     animated: true)
+                overlay?.tintColor = self.theme["tintColor"]
                 
-                copyPost(post)
+                ForumsClient.shared.quoteBBcodeContents(of: post)
+                    .done { [weak self] bbcode in
+                        guard self != nil else { return }
+                        UIPasteboard.general.string = bbcode
+                    }
+                    .catch { [weak self] error in
+                        guard let self = self else { return }
+                        let alert = UIAlertController(title: LocalizedString("posts-page.error.could-not-copy-post"), error: error)
+                        self.present(alert, animated: true)
+                    }
+                    .finally {
+                        overlay?.dismiss(true)
+                    }
             }))
         }
         

--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -637,7 +637,7 @@ final class PostsPageViewController: ViewController {
             }
         }()
         
-        composeItem.isEnabled = !thread.closed && thread.forum?.canPost == true
+        composeItem.isEnabled = !thread.closed
     }
     
     private func showLoadingView() {

--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -956,7 +956,7 @@ final class PostsPageViewController: ViewController {
                             self.present(replyWorkspace.viewController, animated: true)
                         }
                         .catch { [weak self] error in
-                            let alert = UIAlertController(title: "Could Not Edit Post", error: error)
+                            let alert = UIAlertController(title: LocalizedString("posts-page.error.could-not-edit-post"), error: error)
                             self?.present(alert, animated: true)
                     }
                 }
@@ -1015,6 +1015,34 @@ final class PostsPageViewController: ViewController {
                     makeNewReplyWorkspace()
                     quotePost()
                 }
+            }))
+        } else {
+            items.append(IconActionItem(.copyPost, block: {
+                func copyPost(_ post: Post) {
+                    let overlay = MRProgressOverlayView.showOverlayAdded(to: self.postsView.renderView,
+                                                                         title: LocalizedString("posts-page.copied-post"),
+                                                                         mode: .checkmark,
+                                                                         animated: true)
+                    overlay?.tintColor = self.theme["tintColor"]
+                 
+                    ForumsClient.shared.quoteBBcodeContents(of: post)
+                        .done { [weak self] bbcode in
+                            guard self != nil else { return }
+                            UIPasteboard.general.string = bbcode
+                        }
+                        .catch { [weak self] error in
+                            guard let self = self else { return }
+                            let alert = UIAlertController(title: LocalizedString("posts-page.error.could-not-copy-post"), error: error)
+                            self.present(alert, animated: true)
+                        }
+                        .finally {
+                            DispatchQueue.main.async {
+                                overlay?.dismiss(true)
+                            }
+                        }
+                }
+                
+                copyPost(post)
             }))
         }
         

--- a/AwfulCore/Sources/AwfulCore/Networking/ForumsClient.swift
+++ b/AwfulCore/Sources/AwfulCore/Networking/ForumsClient.swift
@@ -221,7 +221,6 @@ public final class ForumsClient {
                 let threads = try result.upsert(into: context)
                 _ = try result.upsertAnnouncements(into: context)
                 
-                // we only know if the forum allows posting while scraping forumdisplay.php
                 forum.canPost = result.canPostNewThread
                 
                 if

--- a/AwfulCore/Sources/AwfulCore/Networking/ForumsClient.swift
+++ b/AwfulCore/Sources/AwfulCore/Networking/ForumsClient.swift
@@ -220,7 +220,10 @@ public final class ForumsClient {
             .map(on: backgroundContext) { result, context -> [NSManagedObjectID] in
                 let threads = try result.upsert(into: context)
                 _ = try result.upsertAnnouncements(into: context)
-
+                
+                // we only know if the forum allows posting while scraping forumdisplay.php
+                forum.canPost = result.canPostNewThread
+                
                 if
                     page == 1,
                     var threadsToForget = threads.first?.forum?.threads

--- a/AwfulCore/Sources/AwfulCore/Persistence/ForumPersistence.swift
+++ b/AwfulCore/Sources/AwfulCore/Persistence/ForumPersistence.swift
@@ -65,6 +65,10 @@ extension ForumBreadcrumbsScrapeResult {
 
         for forum in forums {
             if group != forum.group { forum.group = group }
+
+            if forum.group?.groupID == ForumGroupID.archives.rawValue {
+                forum.canPost = false
+            }
         }
 
         return (group: group, forums: forums)

--- a/AwfulCore/Sources/AwfulCore/Scraping/Helpers.swift
+++ b/AwfulCore/Sources/AwfulCore/Scraping/Helpers.swift
@@ -127,3 +127,7 @@ func scrapePageDropdown(_ node: HTMLNode) -> (pageNumber: Int?, pageCount: Int?)
 
     return (pageNumber: pageNumber, pageCount: pageCount)
 }
+
+enum ForumGroupID: String {
+    case archives = "49"
+}


### PR DESCRIPTION
New option currently only displays on closed threads, but could easily be made an additional option for open threads, if that's useful.

This feature prompted by [post516376543](https://forums.somethingawful.com/showthread.php?threadid=3837546&pagenumber=105#post516376543)

Commit also includes a fix where forums that don't allow posting (goldmine, etc) did not disable the Compose icon.