### PR TITLE
Fix for YouTube embed long-press menu items.

### DIFF
--- a/App/Misc/HTMLRenderingHelpers.swift
+++ b/App/Misc/HTMLRenderingHelpers.swift
@@ -453,6 +453,6 @@ private func getYoutubeEmbeddedUri(uri: String) -> String? {
         return nil
     }
     return """
-    https://www.youtube-nocookie.com/embed/\(id!)\(secondsString)
+    https://www.youtube.com/embed/\(id!)\(secondsString)
     """
 }


### PR DESCRIPTION
I somehow removed URLMenuPresenter while adding the Save Video option.
I've added that back and moved the conditions around a bit so that any URL that is not an mp4 will use URLMenuPresenter.
Also removed webm and gifv as allowable conditions since they haven't been tested.