### PR TITLE
Custom user agent for webview: MacOS Chrome agent fixes youtube embed issues

### DIFF
--- a/App/Views/RenderView.swift
+++ b/App/Views/RenderView.swift
@@ -52,6 +52,10 @@ final class RenderView: UIView {
         webView.navigationDelegate = self
         webView.scrollView.backgroundColor = nil
         webView.scrollView.decelerationRate = .normal
+        
+        // this fixes youtube embeds in multiple ways!
+        webView.customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36"
+        
         return webView
     }()
 


### PR DESCRIPTION
For a description of the issue, see this page: https://forums.somethingawful.com/showthread.php?threadid=3837546&pagenumber=110#post517653021

Validated this by:
- Testing multiple times between the MacOS Chrome user agent and no user agent. Issue reliably occurred without any user agent, while never occurring with this change.
- Tried the latest iOS Safari user agent, as maybe the lack of ANY user agent could be the issue (and the Chrome user agent may not be what's fixing it.) However, the issue occurred with this agent value.
- Tried the latest iOS Chrome user agent. As maybe it IS due to Chrome being favoured. However, the issue also occurred with this agent value. Seems more of a Mobile vs Desktop issue.

After all this testing, the agent string being submitted here seems to work reliably. Gonna make this a PR so that you can confirm :)