### PR TITLE
iOS 15 scroll thumb dark in dark view & webview user agent update

### DIFF
--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -1286,6 +1286,7 @@ final class PostsPageViewController: ViewController {
         super.viewDidAppear(animated)
         
         configureUserActivityIfPossible()
+        self.postsView.renderView.makeOpaqueToFixIOS15ScrollThumbColor()
     }
     
     override func viewDidDisappear(_ animated: Bool) {

--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -1286,7 +1286,7 @@ final class PostsPageViewController: ViewController {
         super.viewDidAppear(animated)
         
         configureUserActivityIfPossible()
-        self.postsView.renderView.makeOpaqueToFixIOS15ScrollThumbColor()
+        self.postsView.renderView.makeWebViewOpaqueToFixIOS15ScrollThumbColor()
     }
     
     override func viewDidDisappear(_ animated: Bool) {

--- a/App/Views/RenderView.swift
+++ b/App/Views/RenderView.swift
@@ -358,6 +358,12 @@ extension RenderView {
         }
     }
     
+    /// dark mode, iOS 15 and transparent views = dark scroll thumbs regardless of appearance
+    /// making the webView opaque after it has loaded means white scroll indicator works and no white flashes on page loads
+    func makeOpaqueToFixIOS15ScrollThumbColor() {
+        webView.isOpaque = true
+    }
+    
     /**
      Removes all previously-loaded content.
      

--- a/App/Views/RenderView.swift
+++ b/App/Views/RenderView.swift
@@ -358,9 +358,9 @@ extension RenderView {
         }
     }
     
-    /// dark mode, iOS 15 and transparent views = dark scroll thumbs regardless of appearance
+    /// iOS 15 and transparent webviews = dark "missing" scroll thumbs, regardless of settings applied
     /// making the webView opaque after it has loaded means white scroll indicator works and no white flashes on page loads
-    func makeOpaqueToFixIOS15ScrollThumbColor() {
+    func makeWebViewOpaqueToFixIOS15ScrollThumbColor() {
         webView.isOpaque = true
     }
     


### PR DESCRIPTION
ResourceURLProtocol.swift:
- Please don't actually commit the ResourceURLProtocol.swift updates! I'm submitting it because I've been needing to do this in order to build in Xcode 13. Could you please see what actually should be done here? Can't add availability attributes to enums

RenderView.swift:
There's an issue limited to iOS 15 where the webview scroll thumb is dark in dark mode aka "missing".
- I thought this was an iOS issue (https://developer.apple.com/forums/thread/689654) and it could well be, but I found that setting isOpaque to true fixes it. I looked it up and this seems more resource-intensive than false, so I put it in a condition for iOS 15 only.
- Also, see the commented code just above on line 50. I tried setting this during troubleshooting and it didn't really impact anything. But leaving it as it may be good to use anyway? Please modify as you see fit
- So I found the custom user agent you mentioned already being in use for network calls (I didn't see it before). I've added it here, replacing the Chrome desktop agent. This one also works! Tested with and without it, etc.