### PR TITLE
Additional character encoding on postbody html

### DIFF
--- a/Awful.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Awful.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/Awful.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Awful.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/nolanw/HTMLReader",
         "state": {
           "branch": null,
-          "revision": "ed927c7287bc45f07f69cb390ad2494e2deecffc",
-          "version": "2.1.7"
+          "revision": "921c203a849930f56f4334f15e6026b3ab99787a",
+          "version": "2.1.8"
         }
       },
       {

--- a/AwfulCore/Package.swift
+++ b/AwfulCore/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(path: "../AwfulSwift"),
         .package(path: "../Logger"),
         .package(url: "https://github.com/mxcl/PromiseKit", .upToNextMajor(from: "6.0.0")),
-        .package(url: "https://github.com/nolanw/HTMLReader", .upToNextMajor(from: "2.1.7")),
+        .package(url: "https://github.com/nolanw/HTMLReader", .upToNextMajor(from: "2.1.8")),
     ],
     targets: [
         .target(

--- a/AwfulCore/Sources/AwfulCore/Persistence/PostPersistence.swift
+++ b/AwfulCore/Sources/AwfulCore/Persistence/PostPersistence.swift
@@ -12,7 +12,18 @@ internal extension PostScrapeResult {
             if authorCanReceivePrivateMessages != user.canReceivePrivateMessages { user.canReceivePrivateMessages = authorCanReceivePrivateMessages }
         }
 
-        if !body.isEmpty, body != post.innerHTML { post.innerHTML = body }
+        if !body.isEmpty, body != post.innerHTML {
+            // converting between charsets resolves an issue with smart punctuation rendering in posts
+            if let latin1Data = body.data(using: .isoLatin1) {
+                if let windowsCP1252String = String(data: latin1Data, encoding: .windowsCP1252){
+                    post.innerHTML = windowsCP1252String
+                } else {
+                    post.innerHTML = body
+                }
+            } else {
+                post.innerHTML = body
+            }
+        }
         if id.rawValue != post.postID { post.postID = id.rawValue }
         if isEditable != post.editable { post.editable = isEditable }
         if isIgnored != post.ignored { post.ignored = isIgnored }

--- a/AwfulScraping/Package.swift
+++ b/AwfulScraping/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["AwfulScraping"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/nolanw/HTMLReader", from: "2.1.4"),
+        .package(url: "https://github.com/nolanw/HTMLReader", from: "2.1.8"),
     ],
     targets: [
         .target(

--- a/Xcode/Awful.xcodeproj/project.pbxproj
+++ b/Xcode/Awful.xcodeproj/project.pbxproj
@@ -160,7 +160,6 @@
 		1C6B2A9A272F992E00671F0C /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = 1C6B2A99272F992E00671F0C /* Nuke */; };
 		1C6BDD22265CB307005475CE /* Imports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6BDD21265CB307005475CE /* Imports.swift */; };
 		1C6BDD24265CB31E005475CE /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = 1C6BDD23265CB31E005475CE /* Logger */; };
-		1C6BDD26265CB337005475CE /* HTMLReader in Frameworks */ = {isa = PBXBuildFile; productRef = 1C6BDD25265CB337005475CE /* HTMLReader */; };
 		1C725A8926E71C6D009713DC /* MRProgress in Frameworks */ = {isa = PBXBuildFile; productRef = 1C725A8826E71C6D009713DC /* MRProgress */; };
 		1C796A25221505250035E154 /* UserDefaults+Settings.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C796A23221505170035E154 /* UserDefaults+Settings.generated.swift */; };
 		1C796A27221505A00035E154 /* UserDefaults+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C796A26221505A00035E154 /* UserDefaults+Settings.swift */; };
@@ -693,7 +692,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1C6BDD26265CB337005475CE /* HTMLReader in Frameworks */,
 				FF308D05C62669BEAFAEA2AC /* Pods_Awful_AwfulTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1514,7 +1512,6 @@
 			);
 			name = AwfulTests;
 			packageProductDependencies = (
-				1C6BDD25265CB337005475CE /* HTMLReader */,
 			);
 			productName = AwfulTests;
 			productReference = 1C9AEBC3210C3B2200C9A567 /* AwfulTests.xctest */;
@@ -1616,10 +1613,10 @@
 			mainGroup = 29B97314FDCFA39411CA2CEA /* Awful */;
 			packageReferences = (
 				1C49CE4922CAF405004B76E6 /* XCRemoteSwiftPackageReference "PromiseKit" */,
-				1CCBDFF822CB02D500E1BE6A /* XCRemoteSwiftPackageReference "HTMLReader" */,
 				1C453F262338457A007AC6CD /* XCRemoteSwiftPackageReference "Stencil" */,
 				1CD72E65265C7FD600FF3BF4 /* XCRemoteSwiftPackageReference "FLAnimatedImage" */,
 				1C6B2A98272F992E00671F0C /* XCRemoteSwiftPackageReference "Nuke" */,
+				2DBC17F327E339E5006F0259 /* XCRemoteSwiftPackageReference "HTMLReader" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
@@ -2662,20 +2659,20 @@
 				minimumVersion = 10.5.1;
 			};
 		};
-		1CCBDFF822CB02D500E1BE6A /* XCRemoteSwiftPackageReference "HTMLReader" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/nolanw/HTMLReader";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.1.7;
-			};
-		};
 		1CD72E65265C7FD600FF3BF4 /* XCRemoteSwiftPackageReference "FLAnimatedImage" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Flipboard/FLAnimatedImage";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.0.16;
+			};
+		};
+		2DBC17F327E339E5006F0259 /* XCRemoteSwiftPackageReference "HTMLReader" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/nolanw/HTMLReader";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -2714,11 +2711,6 @@
 		1C6BDD23265CB31E005475CE /* Logger */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Logger;
-		};
-		1C6BDD25265CB337005475CE /* HTMLReader */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1CCBDFF822CB02D500E1BE6A /* XCRemoteSwiftPackageReference "HTMLReader" */;
-			productName = HTMLReader;
 		};
 		1C725A8826E71C6D009713DC /* MRProgress */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Additional character encoding on postbody html in order to resolve smart punctuation rendering errors that are much more prominent in iOS 15.4

[See #post522136552](https://forums.somethingawful.com/showthread.php?threadid=3837546&pagenumber=123#post522136552)

There are additional updates here because I had an issue building due to HTMLReader submodule github errors after upgrading Xcode. I saw the latest update on github and updated the versions / removed and re-added the dependency. Seems good now

These two things should be reviewed before being committed, hence the PR :)