### PR TITLE
Thread ratings now reflect thread's nstars.gif rating image

### DIFF
--- a/App/Model Presentation/Thread+Presentation.swift
+++ b/App/Model Presentation/Thread+Presentation.swift
@@ -12,8 +12,9 @@ extension AwfulThread {
 
     /// Name of an image suitable for showing the rating below the thread tag.
     var ratingImageName: String? {
-        let rounded = lroundf(rating).clamp(0...5)
-        return rounded != 0 ? "rating\(rating)" : nil
+        let scanner = Scanner(string: ratingImageBasename ?? "")
+        _ = scanner.scanUpToCharacters(from: .decimalDigits)
+        return scanner.scanCharacters(from: .decimalDigits).map { "rating\($0)" }
     }
 
     /// Name of an image suitable for showing the rating as the thread tag itself.

--- a/AwfulCore/Sources/AwfulCore/Model/Awful.xcdatamodeld/.xccurrentversion
+++ b/AwfulCore/Sources/AwfulCore/Model/Awful.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Awful 3.33-beta0.xcdatamodel</string>
+	<string>Awful 6.2.xcdatamodel</string>
 </dict>
 </plist>

--- a/AwfulCore/Sources/AwfulCore/Model/Awful.xcdatamodeld/Awful 6.2.xcdatamodel/contents
+++ b/AwfulCore/Sources/AwfulCore/Model/Awful.xcdatamodeld/Awful 6.2.xcdatamodel/contents
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Announcement" representedClassName="Announcement" syncable="YES">
+        <attribute name="authorCustomTitleHTML" attributeType="String"/>
+        <attribute name="authorRegdate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="authorUsername" attributeType="String"/>
+        <attribute name="bodyHTML" attributeType="String"/>
+        <attribute name="hasBeenSeen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="listIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="postedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="announcements" inverseEntity="User"/>
+        <relationship name="threadTag" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ThreadTag" inverseName="announcements" inverseEntity="ThreadTag"/>
+        <fetchIndex name="compoundIndex">
+            <fetchIndexElement property="listIndex" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Forum" representedClassName="Forum" syncable="YES">
+        <attribute name="canPost" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO"/>
+        <attribute name="forumID" attributeType="String"/>
+        <attribute name="index" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO"/>
+        <attribute name="lastFilteredRefresh" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastRefresh" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <relationship name="childForums" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Forum" inverseName="parentForum" inverseEntity="Forum"/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ForumGroup" inverseName="forums" inverseEntity="ForumGroup"/>
+        <relationship name="metadata" maxCount="1" deletionRule="Cascade" destinationEntity="ForumMetadata" inverseName="forum" inverseEntity="ForumMetadata"/>
+        <relationship name="parentForum" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Forum" inverseName="childForums" inverseEntity="Forum"/>
+        <relationship name="secondaryThreadTags" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ThreadTag" inverseName="secondaryForums" inverseEntity="ThreadTag"/>
+        <relationship name="threads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Thread" inverseName="forum" inverseEntity="Thread"/>
+        <relationship name="threadTags" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ThreadTag" inverseName="forums" inverseEntity="ThreadTag"/>
+        <fetchIndex name="byForumIDIndex">
+            <fetchIndexElement property="forumID" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="ForumGroup" representedClassName="ForumGroup" syncable="YES">
+        <attribute name="groupID" attributeType="String"/>
+        <attribute name="index" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="sectionIdentifier" optional="YES" transient="YES" attributeType="String"/>
+        <relationship name="forums" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Forum" inverseName="group" inverseEntity="Forum"/>
+        <fetchIndex name="byGroupIDIndex">
+            <fetchIndexElement property="groupID" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="ForumMetadata" representedClassName="ForumMetadata" syncable="YES">
+        <attribute name="favorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="favoriteIndex" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO"/>
+        <attribute name="showsChildrenInForumList" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="visibleInForumList" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <relationship name="forum" maxCount="1" deletionRule="Nullify" destinationEntity="Forum" inverseName="metadata" inverseEntity="Forum"/>
+    </entity>
+    <entity name="Post" representedClassName="Post" syncable="YES">
+        <attribute name="editable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="filteredThreadIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="ignored" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="innerHTML" optional="YES" attributeType="String"/>
+        <attribute name="lastModifiedDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="postDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="postID" attributeType="String"/>
+        <attribute name="threadIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <relationship name="author" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="posts" inverseEntity="User"/>
+        <relationship name="thread" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Thread" inverseName="posts" inverseEntity="Thread"/>
+        <fetchIndex name="byPostIDIndex">
+            <fetchIndexElement property="postID" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="PrivateMessage" representedClassName="PrivateMessage" syncable="YES">
+        <attribute name="forwarded" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="innerHTML" optional="YES" attributeType="String"/>
+        <attribute name="lastModifiedDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="messageID" attributeType="String"/>
+        <attribute name="rawFromUsername" optional="YES" attributeType="String"/>
+        <attribute name="replied" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="seen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="sentDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="subject" optional="YES" attributeType="String"/>
+        <relationship name="from" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="sentPrivateMessages" inverseEntity="User"/>
+        <relationship name="threadTag" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ThreadTag" inverseName="messages" inverseEntity="ThreadTag"/>
+        <relationship name="to" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="receivedPrivateMessages" inverseEntity="User"/>
+        <fetchIndex name="byMessageIDIndex">
+            <fetchIndexElement property="messageID" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Profile" representedClassName="Profile" syncable="YES">
+        <attribute name="aboutMe" optional="YES" attributeType="String"/>
+        <attribute name="aimName" optional="YES" attributeType="String"/>
+        <attribute name="gender" optional="YES" attributeType="String"/>
+        <attribute name="homepageURL" optional="YES" attributeType="Transformable"/>
+        <attribute name="icqName" optional="YES" attributeType="String"/>
+        <attribute name="interests" optional="YES" attributeType="String"/>
+        <attribute name="lastModifiedDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastPostDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="location" optional="YES" attributeType="String"/>
+        <attribute name="occupation" optional="YES" attributeType="String"/>
+        <attribute name="postCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="postRate" optional="YES" attributeType="String"/>
+        <attribute name="profilePictureURL" optional="YES" attributeType="Transformable"/>
+        <attribute name="yahooName" optional="YES" attributeType="String"/>
+        <relationship name="user" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="profile" inverseEntity="User"/>
+    </entity>
+    <entity name="Thread" representedClassName="Thread" syncable="YES">
+        <attribute name="anyUnreadPosts" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO"/>
+        <attribute name="archived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="bookmarked" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="bookmarkListPage" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="closed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="lastModifiedDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastPostAuthorName" optional="YES" attributeType="String"/>
+        <attribute name="lastPostDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="numberOfPages" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="numberOfVotes" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="rating" attributeType="Float" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="ratingImageBasename" optional="YES" attributeType="String"/>
+        <attribute name="seenPosts" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="starCategory" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="sticky" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="stickyIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="threadID" attributeType="String"/>
+        <attribute name="threadListPage" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="totalReplies" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <relationship name="author" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="threads" inverseEntity="User"/>
+        <relationship name="forum" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Forum" inverseName="threads" inverseEntity="Forum"/>
+        <relationship name="posts" toMany="YES" deletionRule="Cascade" destinationEntity="Post" inverseName="thread" inverseEntity="Post"/>
+        <relationship name="secondaryThreadTag" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ThreadTag" inverseName="secondaryThreads" inverseEntity="ThreadTag"/>
+        <relationship name="threadFilters" toMany="YES" deletionRule="Cascade" destinationEntity="ThreadFilter" inverseName="thread" inverseEntity="ThreadFilter"/>
+        <relationship name="threadTag" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ThreadTag" inverseName="threads" inverseEntity="ThreadTag"/>
+        <fetchIndex name="byThreadIDIndex">
+            <fetchIndexElement property="threadID" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="ThreadFilter" representedClassName="ThreadFilter" syncable="YES">
+        <attribute name="numberOfPages" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <relationship name="author" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="threadFilters" inverseEntity="User"/>
+        <relationship name="thread" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Thread" inverseName="threadFilters" inverseEntity="Thread"/>
+        <fetchIndex name="compoundIndex">
+            <fetchIndexElement property="author" type="Binary" order="ascending"/>
+            <fetchIndexElement property="thread" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="ThreadTag" representedClassName="ThreadTag" syncable="YES">
+        <attribute name="imageName" optional="YES" attributeType="String"/>
+        <attribute name="threadTagID" optional="YES" attributeType="String"/>
+        <relationship name="announcements" toMany="YES" deletionRule="Nullify" destinationEntity="Announcement" inverseName="threadTag" inverseEntity="Announcement"/>
+        <relationship name="forums" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Forum" inverseName="threadTags" inverseEntity="Forum"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PrivateMessage" inverseName="threadTag" inverseEntity="PrivateMessage"/>
+        <relationship name="secondaryForums" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Forum" inverseName="secondaryThreadTags" inverseEntity="Forum"/>
+        <relationship name="secondaryThreads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Thread" inverseName="secondaryThreadTag" inverseEntity="Thread"/>
+        <relationship name="threads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Thread" inverseName="threadTag" inverseEntity="Thread"/>
+        <fetchIndex name="byImageNameIndex">
+            <fetchIndexElement property="imageName" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byThreadTagIDIndex">
+            <fetchIndexElement property="threadTagID" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="User" representedClassName="User" syncable="YES">
+        <attribute name="administrator" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="authorClasses" optional="YES" attributeType="String"/>
+        <attribute name="canReceivePrivateMessages" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="customTitleHTML" optional="YES" attributeType="String"/>
+        <attribute name="lastModifiedDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="moderator" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
+        <attribute name="regdate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="userID" attributeType="String"/>
+        <attribute name="username" optional="YES" attributeType="String"/>
+        <relationship name="announcements" toMany="YES" deletionRule="Nullify" destinationEntity="Announcement" inverseName="author" inverseEntity="Announcement"/>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Post" inverseName="author" inverseEntity="Post"/>
+        <relationship name="profile" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Profile" inverseName="user" inverseEntity="Profile"/>
+        <relationship name="receivedPrivateMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PrivateMessage" inverseName="to" inverseEntity="PrivateMessage"/>
+        <relationship name="sentPrivateMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PrivateMessage" inverseName="from" inverseEntity="PrivateMessage"/>
+        <relationship name="threadFilters" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ThreadFilter" inverseName="author" inverseEntity="ThreadFilter"/>
+        <relationship name="threads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Thread" inverseName="author" inverseEntity="Thread"/>
+        <fetchIndex name="byUserIDIndex">
+            <fetchIndexElement property="userID" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUsernameIndex">
+            <fetchIndexElement property="username" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <elements>
+        <element name="Announcement" positionX="36" positionY="162" width="128" height="195"/>
+        <element name="Forum" positionX="0" positionY="0" width="128" height="240"/>
+        <element name="ForumGroup" positionX="27" positionY="171" width="128" height="120"/>
+        <element name="ForumMetadata" positionX="45" positionY="180" width="128" height="120"/>
+        <element name="Post" positionX="0" positionY="0" width="128" height="193"/>
+        <element name="PrivateMessage" positionX="0" positionY="0" width="128" height="223"/>
+        <element name="Profile" positionX="27" positionY="153" width="128" height="270"/>
+        <element name="Thread" positionX="0" positionY="0" width="128" height="419"/>
+        <element name="ThreadFilter" positionX="0" positionY="0" width="128" height="88"/>
+        <element name="ThreadTag" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="285"/>
+    </elements>
+</model>

--- a/AwfulCore/Sources/AwfulCore/Model/Thread.swift
+++ b/AwfulCore/Sources/AwfulCore/Model/Thread.swift
@@ -22,6 +22,7 @@ public class AwfulThread: AwfulManagedObject, Managed {
     @NSManaged internal var primitiveSeenPosts: NSNumber // Would prefer Int32 but that throws EXC_BAD_ACCESS.
     @NSManaged internal var primitiveStarCategory: NSNumber
     @NSManaged public var sticky: Bool
+    @NSManaged public var ratingImageBasename: String?
     @NSManaged public var stickyIndex: Int32
     @NSManaged public var threadID: String
     @NSManaged public var threadListPage: Int32

--- a/AwfulCore/Sources/AwfulCore/Persistence/ThreadPersistence.swift
+++ b/AwfulCore/Sources/AwfulCore/Persistence/ThreadPersistence.swift
@@ -67,6 +67,10 @@ internal extension ThreadListScrapeResult {
 
             if forum != thread.forum { thread.forum = forum }
 
+            if let ratingImageBasename = raw.ratingImageBasename {
+                if ratingImageBasename != thread.ratingImageBasename { thread.ratingImageBasename = ratingImageBasename }
+            }
+          
             if let icon = raw.icon {
                 let tag = iconHelper.upsert(icon)
                 if tag != thread.threadTag { thread.threadTag = tag }
@@ -104,6 +108,11 @@ internal extension ThreadListScrapeResult.Thread {
         if id.rawValue != thread.threadID { thread.threadID = id.rawValue }
         if isClosed != thread.closed { thread.closed = isClosed }
         if isSticky != thread.sticky { thread.sticky = isSticky }
+        
+        if let ratingImageBasename = ratingImageBasename, ratingImageBasename != thread.ratingImageBasename {
+            thread.ratingImageBasename = ratingImageBasename
+        }
+        
         if !lastPostAuthorUsername.isEmpty, lastPostAuthorUsername != thread.lastPostAuthorName { thread.lastPostAuthorName = lastPostAuthorUsername }
         if let lastPostDate = lastPostDate, lastPostDate != thread.lastPostDate as Date? { thread.lastPostDate = lastPostDate as NSDate }
         if let ratingAverage = ratingAverage, ratingAverage != Float(thread.rating) { thread.rating = Float32(ratingAverage) }


### PR DESCRIPTION
Hey, I'm sending this through as a PR as there's another Core Data model update. 

- Added new field to Thread model in Core Data for ratingImageFileName string value.
- Transform filename to rating by discarding non-digits. This replaces the "rounded" value that calculated a rating using maths instead of using the actual rating value from the thread.
- Left the Film Dump rating using rounding alone as that seems to be calculating accurately.