### PR TITLE
Add SwiftUI version of settings screen (awaiting backport to iOS 13 or min SDK bump to iOS 14)

### DIFF
--- a/App/Main/RootViewControllerStack.swift
+++ b/App/Main/RootViewControllerStack.swift
@@ -4,6 +4,7 @@
 
 import CoreData
 import UIKit
+import SwiftUI
 
 /// The RootViewControllerStack initializes the logged-in root view controller, implements releated delegate methods, and handles state restoration.
 final class RootViewControllerStack: NSObject, AwfulSplitViewControllerDelegate {
@@ -44,8 +45,34 @@ final class RootViewControllerStack: NSObject, AwfulSplitViewControllerDelegate 
         
         let lepers = RapSheetViewController()
         lepers.restorationIdentifier = "Leper's Colony"
+   
+        var settings: UIViewController
         
-        let settings = SettingsViewController(managedObjectContext: managedObjectContext)
+        if #available(iOS 14, *) {
+            settings = UIHostingController(rootView: SettingsView(viewModel: .init()).environment(\.managedObjectContext, managedObjectContext))
+            settings.title = LocalizedString("Settings")
+            settings.tabBarItem.title = LocalizedString("Settings")
+        
+            if Theme.defaultTheme().showRootTabBarLabel {
+                settings.tabBarItem.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+                settings.tabBarItem.title = LocalizedString("Settings")
+            } else {
+                settings.tabBarItem.imageInsets = UIEdgeInsets(top: 9, left: 0, bottom: -9, right: 0)
+                settings.tabBarItem.title = nil
+            }
+            
+            settings.tabBarItem.image = UIImage(named: "cog")!
+                                        .withTintColor(Theme.defaultTheme()["tabBarTintColor"]!)
+                                        .withRenderingMode(.alwaysTemplate)
+            
+            settings.tabBarItem.selectedImage = UIImage(named: "cog-filled")!
+                                        .withTintColor(Theme.defaultTheme()["tintColor"]!)
+                                        .withRenderingMode(.alwaysTemplate)
+            
+        } else {
+            settings = SettingsViewController(managedObjectContext: managedObjectContext)
+        }
+    
         settings.restorationIdentifier = "Settings"
         
         tabBarController.restorationIdentifier = "Tabbar"

--- a/App/Settings/SettingsView.swift
+++ b/App/Settings/SettingsView.swift
@@ -1,0 +1,367 @@
+//  SettingsView.swift
+//
+//  Copyright 2022 Awful Contributors. CC BY-NC-SA 3.0 US https://github.com/Awful/Awful.app
+
+import SwiftUI
+import NukeUI
+import AwfulCore
+
+private let Log = Logger.get()
+
+@available(iOS 14.0, *)
+class SettingsViewModel: Identifiable, ObservableObject {
+    @SwiftUI.Environment(\.managedObjectContext) var managedObjectContext
+    @AppStorage("show_images") var loadImages = true
+    @AppStorage("show_avatars") var showAvatars = true
+    @AppStorage("font_scale") var fontScale = 100
+    @AppStorage("confirm_before_replying") var confirmBeforeReply = true
+    @AppStorage("autoplay_gifs") var autoplayGIFs = true
+    @AppStorage("embed_tweets") var embedTweets = true
+    @AppStorage("jump_to_post_end_on_double_tap") var doubleTapJump = true
+    @AppStorage("enable_haptics") var enableHaptics = true
+    @AppStorage("automatic_timg") var autoTIMG = true
+    @AppStorage("bookmarks_sorted_unread") var sortUnreadBookmarks = true
+    @AppStorage("show_thread_tags") var showThreadTags = true
+    @AppStorage("forum_threads_sorted_unread") var sortUnreadThreads = true
+    @AppStorage("pull_for_next") var pullForNext = true
+    @AppStorage("hide_sidebar_in_landscape") var hideSidebarInLandscape = true
+    @AppStorage("open_youtube_links_in_youtube") var openInYoutube = true
+    @AppStorage("open_twitter_links_in_twitter") var openInTwitter = true
+    @AppStorage("dark_theme") var darkModeEnabled = true
+    @AppStorage("auto_dark_theme") var automaticDarkModeEnabled = true
+    @AppStorage("handoff_enabled") var handoffEnabled = true
+    @AppStorage("clipboard_url_enabled") var clipboardURLEnabled = true
+    @AppStorage("show_unread_announcements_badge") var showUnreadAnnouncements = true
+    @AppStorage("default_dark_theme_name") var defaultDarkTheme = ""
+    @AppStorage("default_light_theme_name") var defaultLightTheme = ""
+        
+    var expiryDate = DateFormatter.localizedString(from: ForumsClient.shared.loginCookieExpiryDate ?? .distantFuture, dateStyle: .medium, timeStyle: .short)
+    
+    func getloggedInUser() -> User? {
+        guard let userID = UserDefaults.standard.loggedInUserID else { return nil }
+        let userKey = UserKey(userID: userID, username: UserDefaults.standard.loggedInUsername)
+        return User.objectForKey(objectKey: userKey, in: ForumsClient.shared.managedObjectContext!)
+    }
+    
+    var version: String = {
+        let title: String = {
+            var components = [Bundle.main.localizedName, Bundle.main.shortVersionString]
+            if Environment.isDebugBuild || Environment.isSimulator || Environment.isInstalledViaTestFlight {
+                components.append(Bundle.main.version.map { "(\($0))" })
+            }
+            return components.compactMap { $0 }.joined(separator: " ")
+        }()
+        return title
+    }()
+    
+}
+
+
+@available(iOS 14.0, *)
+struct SettingsView: View {
+    @ObservedObject var viewModel: SettingsViewModel
+    @SwiftUI.Environment(\.managedObjectContext) var managedObjectContext
+    @SwiftUI.Environment(\.colorScheme) var colorScheme
+    
+    var body: some View {
+        ZStack {
+            Color(Theme.defaultTheme()[color: "backgroundColor"] ?? .clear).ignoresSafeArea()
+            Form {
+                Group {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(self.viewModel.getloggedInUser()?.username ?? "Preview Pete")
+                            Text(self.viewModel.getloggedInUser()?.regdateRaw ?? "01 Jan 2000")
+                            
+                            if (self.viewModel.getloggedInUser()?.avatarURLString) != nil {
+                                LazyImage(source: self.viewModel.getloggedInUser()?.avatarURLString)
+                                    .frame(width: 100, height: 100)
+                            } else {
+                                Image("title-probation").frame(width: 100, height: 100).padding()
+                            }
+                            Text("Cookie expires on \(self.viewModel.expiryDate)")
+                                .font(.system(.caption, design: .rounded))
+                        }
+                    }
+                    Section {
+                        Button("Log Out"){
+                            AppDelegate.instance.logOut();
+                        }
+                        Button("Empty Cache"){
+                            AppDelegate.instance.emptyCache();
+                        }
+                        Button("Go To Thread"){
+                            AppDelegate.instance.open(route: .threadPage(threadID: "3837546", page: .nextUnread, .seen))
+                        }
+                    }
+                    SettingsSections(viewModel: self.viewModel)
+                }
+                .listRowBackground(Color(Theme.defaultTheme()[color: "backgroundColor"] ?? .clear))
+                .foregroundColor(colorScheme == .dark ? .white : .black)
+                .awfulToggleStyle()
+            }
+            .onAppear {
+                UITableView.appearance().backgroundColor = .clear
+                UITableView.appearance().separatorColor = .clear
+            }
+            .onChange(of: self.viewModel.$darkModeEnabled.wrappedValue) { newValue in
+                UITableView.appearance().backgroundColor = .clear
+                UITableView.appearance().separatorColor = .clear
+            }
+            .onChange(of: self.viewModel.$defaultDarkTheme.wrappedValue) { newValue in
+                UITableView.appearance().backgroundColor = .clear
+                UITableView.appearance().separatorColor = .clear
+            }
+            .onChange(of: self.viewModel.$defaultLightTheme.wrappedValue) { newValue in
+                UITableView.appearance().backgroundColor = .clear
+                UITableView.appearance().separatorColor = .clear
+            }
+        }
+        .foregroundColor(colorScheme == .dark ? .white : .black)
+    }
+}
+
+@available(iOS 14.0, *)
+struct SettingsSections: View {
+    var viewModel: SettingsViewModel
+    @SwiftUI.Environment(\.managedObjectContext) var managedObjectContext
+    
+    var body: some View {
+        
+        // MARK: Posts
+        Section(header: Text("Posts")
+            .font(.system(.caption, design: .rounded))){
+                Toggle("Show Avatars", isOn: viewModel.$showAvatars)
+                Toggle("Load Images", isOn: viewModel.$loadImages)
+                Stepper("Scale Text \(viewModel.$fontScale.wrappedValue)%", value: self.viewModel.$fontScale, in: 100...200, step: 10)
+                Toggle("Always Preview New Posts", isOn: viewModel.$confirmBeforeReply)
+                Toggle("Always Animate GIFs", isOn: viewModel.$autoplayGIFs)
+                Toggle("Embed Tweets", isOn: viewModel.$embedTweets)
+                Toggle("Double-Tap Skips To Bottom", isOn: viewModel.$doubleTapJump)
+                Toggle("Enable Haptics", isOn: viewModel.$enableHaptics)
+            }
+        
+        // MARK: Posting
+        Section(header: Text("Posting")
+            .font(.system(.caption, design: .rounded))){
+                Toggle("[timg] Large Images", isOn: viewModel.$autoTIMG)
+            }
+        
+        // MARK: Threads
+        Section(header: Text("Threads")
+            .font(.system(.caption, design: .rounded))){
+                Toggle("Show Thread Tags", isOn: viewModel.$showThreadTags)
+                Toggle("Sort Unread Bookmarks First", isOn: viewModel.$sortUnreadBookmarks)
+                Toggle("Sort Unread Threads First", isOn: viewModel.$sortUnreadThreads)
+                Toggle("Pull For Next Page", isOn: viewModel.$pullForNext)
+            }
+        
+        // MARK: Sidebar
+        Section(header: Text("Sidebar")
+            .font(.system(.caption, design: .rounded))){
+                Toggle("Hide Sidebar In Landscape", isOn: viewModel.$hideSidebarInLandscape)
+            }
+        
+        // MARK: Default Browser
+        Section(footer: Text("What to open when tapping an external link. Long-press any link for more options.")) {
+            NavigationLink(destination: DefaultBrowserSelector()) {
+                Text("Default Browser")
+            }
+            Toggle("Open YouTube in YouTube", isOn: self.viewModel.$openInYoutube)
+            Toggle("Open Twitter in Twitter", isOn: self.viewModel.$openInTwitter)
+        }
+        
+        // MARK: Themes
+        Section(
+            header: Text("Themes").font(.system(.caption, design: .rounded)),
+            footer: Text("Awful can automatically switch between light and dark themes alongside iOS.").font(.system(.caption, design: .rounded))) {
+            NavigationLink(destination: SettingsThemePickerViewSwiftUI(defaultMode: Theme.Mode.light)) {
+                Text("Default Light Theme")
+            }
+            NavigationLink(destination: SettingsThemePickerViewSwiftUI(defaultMode: Theme.Mode.dark)) {
+                Text("Default Dark Theme")
+            }
+            NavigationLink(destination: ForumSpecificThemes().environment(\.managedObjectContext, managedObjectContext)) {
+                Text("Forum-Specific Themes")
+            }
+            Toggle("Dark Mode", isOn: self.viewModel.$darkModeEnabled)
+            Toggle("Automatic Dark Mode", isOn: self.viewModel.$automaticDarkModeEnabled)
+        }
+        
+        // MARK: Handoff
+        Section(footer: Text("Handoff allows you to continue reading threads on nearby devices.").font(.system(.caption, design: .rounded))) {
+            Toggle("Handoff", isOn: self.viewModel.$handoffEnabled)
+        }
+        
+        // MARK: Clipboard
+        Section(footer: Text("Checking the clipboard for a forums URL when you open the app allows you to jump straight to a copied URL in Awful.").font(.system(.caption, design: .rounded))) {
+            Toggle("Check Clipboard for URL", isOn: self.viewModel.$clipboardURLEnabled)
+        }
+        
+        // MARK: App Icon
+        Section(header: Text("App Icon").font(.system(.caption, design: .rounded))) {
+            AppIconPickerView()
+        }
+        
+        // MARK: Unread Announcements
+        Section {
+            Toggle("Unread announcements badge", isOn: self.viewModel.$showUnreadAnnouncements)
+        }
+    }
+}
+
+// MARK: SwiftUI Preview
+
+@available(iOS 14.0, *)
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            SettingsView(viewModel: .init())
+        }
+    }
+}
+
+
+// MARK: SwiftUI Helpers
+
+extension Binding {
+    func onChange(_ handler: @escaping (Value) -> Void) -> Binding<Value> {
+        Binding(
+            get: { self.wrappedValue },
+            set: { newValue in
+                self.wrappedValue = newValue
+                handler(newValue)
+            }
+        )
+    }
+}
+
+struct AwfulListStyle: ViewModifier {
+    @State var bgColor = Color(Theme.defaultTheme()[color: "backgroundColor"]!)
+    func body(content: Content) -> some View {
+        content
+            .listRowBackground(bgColor)
+    }
+}
+
+struct AwfulToggleStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 15.0, *) {
+            content
+                .tint(Color(uiColor: Theme.defaultTheme()["settingsSwitchColor"]!))
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    func awfulToggleStyle() -> some View {
+        modifier(AwfulToggleStyle())
+    }
+    func awfulListStyle() -> some View {
+        modifier(AwfulListStyle())
+    }
+}
+
+
+// MARK: UIKit embeds
+
+struct ForumSpecificThemes: UIViewControllerRepresentable {
+    @SwiftUI.Environment(\.managedObjectContext) var managedObjectContext
+    
+    typealias UIViewControllerType = SettingsForumSpecificThemesViewController
+    
+    func makeUIViewController(context: Context) -> SettingsForumSpecificThemesViewController {
+        let myViewController = SettingsForumSpecificThemesViewController(context: managedObjectContext)
+        // myView.delegate = context.coordinator
+        return myViewController
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+        // left blank
+    }
+    
+    func makeCoordinator() -> ForumSpecificThemes.Coordinator {
+        return Coordinator(self)
+    }
+}
+
+extension ForumSpecificThemes {
+    class Coordinator /*: SomeUIKitViewDelegate */ {
+        var parent: ForumSpecificThemes
+        
+        init(_ parent: ForumSpecificThemes) {
+            self.parent = parent
+        }
+        
+        // Implement delegate methods here
+    }
+}
+
+
+struct SettingsThemePickerViewSwiftUI: UIViewControllerRepresentable {
+    var defaultMode: Theme.Mode
+    
+    typealias UIViewControllerType = SettingsThemePickerViewController
+    
+    func makeUIViewController(context: Context) -> SettingsThemePickerViewController {
+        let myViewController = SettingsThemePickerViewController(defaultMode: defaultMode)
+        // myView.delegate = context.coordinator
+        return myViewController
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+        // left blank
+        
+    }
+    
+    func makeCoordinator() -> SettingsThemePickerViewSwiftUI.Coordinator {
+        return Coordinator(self)
+    }
+}
+
+extension SettingsThemePickerViewSwiftUI {
+    class Coordinator /*: SomeUIKitViewDelegate */ {
+        var parent: SettingsThemePickerViewSwiftUI
+        
+        init(_ parent: SettingsThemePickerViewSwiftUI) {
+            self.parent = parent
+        }
+        
+        // Implement delegate methods here
+    }
+}
+
+
+struct ProfileViewUIKit: UIViewControllerRepresentable {
+    typealias UIViewControllerType = ProfileViewController
+    
+    var loggedInUser: User
+    
+    func makeUIViewController(context: Context) -> ProfileViewController {
+        let myViewController = ProfileViewController(user: loggedInUser)
+        // myView.delegate = context.coordinator
+        return myViewController
+    }
+    
+    func updateUIViewController(_ uiViewController: ProfileViewController, context: Context) {
+        //
+    }
+    
+}
+
+struct DefaultBrowserSelector: UIViewControllerRepresentable {
+    func updateUIViewController(_ uiViewController: SettingsDefaultBrowserController, context: Context) {
+        //
+    }
+    
+    typealias UIViewControllerType = SettingsDefaultBrowserController
+    
+    func makeUIViewController(context: Context) -> SettingsDefaultBrowserController {
+        let myViewController = SettingsDefaultBrowserController()
+        // myView.delegate = context.coordinator
+        return myViewController
+    }
+    
+}

--- a/App/Views/AppIconPickerView.swift
+++ b/App/Views/AppIconPickerView.swift
@@ -1,0 +1,37 @@
+//  AppIconPickerView.swift
+//
+//  Copyright 2022 Awful Contributors. CC BY-NC-SA 3.0 US https://github.com/Awful/Awful.app
+
+import SwiftUI
+
+struct AppIconPickerView: View {
+    
+    let appIcons: [AppIcon] = findAppIcons()
+    
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack{
+                ForEach(appIcons, id: \.iconName) { icon in
+                    Button(action: {
+                        if icon.iconName == "AppIcon" {
+                            UIApplication.shared.setAlternateIconName(nil)
+                        } else {
+                            UIApplication.shared.setAlternateIconName(icon.iconName)
+                        }
+                    }){
+                        Image("\(icon.iconName)Image")
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    }
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct AppIconPickerView_Previews: PreviewProvider {
+    static var previews: some View {
+        AppIconPickerView()
+    }
+}
+#endif

--- a/Awful.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Awful.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "Gifu",
+        "repositoryURL": "https://github.com/kaishin/Gifu",
+        "state": {
+          "branch": null,
+          "revision": "51f2eab32903e336f590c013267cfa4d7f8b06c4",
+          "version": "3.3.1"
+        }
+      },
+      {
         "package": "HTMLReader",
         "repositoryURL": "https://github.com/nolanw/HTMLReader",
         "state": {
@@ -26,6 +35,15 @@
           "branch": null,
           "revision": "472a03c15f39592007d94f25abe554350bc8aa2b",
           "version": "10.5.1"
+        }
+      },
+      {
+        "package": "NukeUI",
+        "repositoryURL": "https://github.com/kean/NukeUI.git",
+        "state": {
+          "branch": null,
+          "revision": "17f26c07e6b1d3b9258287f99f528111fcd7b7ad",
+          "version": "0.8.1"
         }
       },
       {

--- a/Xcode/Awful.xcodeproj/project.pbxproj
+++ b/Xcode/Awful.xcodeproj/project.pbxproj
@@ -234,6 +234,9 @@
 		1CF6786B201E751D009A9640 /* MessageListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF6786A201E751D009A9640 /* MessageListDataSource.swift */; };
 		1CF6786E201E8F45009A9640 /* MessageListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF6786D201E8F45009A9640 /* MessageListCell.swift */; };
 		1CFC996A1BD3F402001180A7 /* PostsPageRefreshArrowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CFC99691BD3F402001180A7 /* PostsPageRefreshArrowView.swift */; };
+		2D0BB35D27F4443F00242D2A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0BB35C27F4443F00242D2A /* SettingsView.swift */; };
+		2D0BB36027F4445D00242D2A /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 2D0BB35F27F4445D00242D2A /* NukeUI */; };
+		2D0BB36327F4473300242D2A /* AppIconPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0BB36227F4473300242D2A /* AppIconPickerView.swift */; };
 		2D0BB37427F453B600242D2A /* ChidoriMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0BB37027F453B600242D2A /* ChidoriMenu.swift */; };
 		2D0BB37527F453B600242D2A /* ChidoriPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0BB37127F453B600242D2A /* ChidoriPresentationController.swift */; };
 		2D0BB37627F453B600242D2A /* ChidoriMenuTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0BB37227F453B600242D2A /* ChidoriMenuTableViewCell.swift */; };
@@ -608,6 +611,8 @@
 		253A5104248FE92D0D619212 /* Pods-Awful-AwfulTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Awful-AwfulTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Awful-AwfulTests/Pods-Awful-AwfulTests.release.xcconfig"; sourceTree = "<group>"; };
 		27F783E9D241CF6339BFCF0B /* Pods_CoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CoreTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D0BB35827F440AF00242D2A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		2D0BB35C27F4443F00242D2A /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		2D0BB36227F4473300242D2A /* AppIconPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppIconPickerView.swift; sourceTree = "<group>"; };
 		2D0BB37027F453B600242D2A /* ChidoriMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriMenu.swift; sourceTree = "<group>"; };
 		2D0BB37127F453B600242D2A /* ChidoriPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriPresentationController.swift; sourceTree = "<group>"; };
 		2D0BB37227F453B600242D2A /* ChidoriMenuTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriMenuTableViewCell.swift; sourceTree = "<group>"; };
@@ -716,6 +721,7 @@
 				1C5C2B8D22D195BF00EA5A80 /* ImgurAnonymousAPI in Frameworks */,
 				1C725A8926E71C6D009713DC /* MRProgress in Frameworks */,
 				D5035BC16B0E9C1817003AF2 /* Pods_Awful.framework in Frameworks */,
+				2D0BB36027F4445D00242D2A /* NukeUI in Frameworks */,
 				1C47122A2664CB8000E5AA74 /* Smilies in Frameworks */,
 				1C6BDD24265CB31E005475CE /* Logger in Frameworks */,
 			);
@@ -1126,6 +1132,7 @@
 				1C54D30A19BBC717002AC6B9 /* SettingsBinding.m */,
 				1C796A2C2219EC1C0035E154 /* SettingsSection.swift */,
 				1C796A26221505A00035E154 /* UserDefaults+Settings.swift */,
+				2D0BB35C27F4443F00242D2A /* SettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -1345,6 +1352,7 @@
 		1CF7FACB1BB60C2200A077F2 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				2D0BB36227F4473300242D2A /* AppIconPickerView.swift */,
 				1CC22AB419F972C200D5BABD /* HairlineView.swift */,
 				1C16FC011CC29B2C00C88BD1 /* LoadingView.swift */,
 				1CD9FB631D1A38030070C8C7 /* NigglyRefreshView.swift */,
@@ -1560,6 +1568,7 @@
 				1C4712292664CB8000E5AA74 /* Smilies */,
 				1C725A8826E71C6D009713DC /* MRProgress */,
 				1C6B2A99272F992E00671F0C /* Nuke */,
+				2D0BB35F27F4445D00242D2A /* NukeUI */,
 			);
 			productName = Awful;
 			productReference = 1D6058910D05DD3D006BFB54 /* AwfulDebug.app */;
@@ -1632,6 +1641,7 @@
 				1C453F262338457A007AC6CD /* XCRemoteSwiftPackageReference "Stencil" */,
 				1CD72E65265C7FD600FF3BF4 /* XCRemoteSwiftPackageReference "FLAnimatedImage" */,
 				1C6B2A98272F992E00671F0C /* XCRemoteSwiftPackageReference "Nuke" */,
+				2D0BB35E27F4445D00242D2A /* XCRemoteSwiftPackageReference "NukeUI" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
@@ -1954,6 +1964,7 @@
 				1C16FC0E1CC477B200C88BD1 /* ThreadTagPickerViewController.swift in Sources */,
 				1C796A292218C41F0035E154 /* DefaultBrowser.swift in Sources */,
 				1CB5F7F5201527550046D080 /* ThreadListCell.swift in Sources */,
+				2D0BB36327F4473300242D2A /* AppIconPickerView.swift in Sources */,
 				1C25AC4B1F537A9600977D6F /* WebViewAntiHijacking.swift in Sources */,
 				1CD005D11BB8800800232FFD /* ThreadsTableViewController.swift in Sources */,
 				1C25AC4F1F576BC600977D6F /* ContextObjectsDidChangeNotification.swift in Sources */,
@@ -1962,6 +1973,7 @@
 				1CFC996A1BD3F402001180A7 /* PostsPageRefreshArrowView.swift in Sources */,
 				1CE2B76819C2372200FDC33E /* LoginViewController.swift in Sources */,
 				1C16FBD51CBA91ED00C88BD1 /* PostsViewExternalStylesheetLoader.swift in Sources */,
+				2D0BB35D27F4443F00242D2A /* SettingsView.swift in Sources */,
 				1CB15BFB1A9EC9C800176E73 /* ReportPostViewController.swift in Sources */,
 				1C25AC4D1F5768D200977D6F /* ManagedObjectCountObserver.swift in Sources */,
 				1C54D30B19BBC717002AC6B9 /* SettingsBinding.m in Sources */,
@@ -2694,6 +2706,14 @@
 				minimumVersion = 1.0.16;
 			};
 		};
+		2D0BB35E27F4445D00242D2A /* XCRemoteSwiftPackageReference "NukeUI" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/NukeUI.git";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.8.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2743,6 +2763,11 @@
 		1CD72E78265CA0D500FF3BF4 /* AwfulCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AwfulCore;
+		};
+		2D0BB35F27F4445D00242D2A /* NukeUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2D0BB35E27F4445D00242D2A /* XCRemoteSwiftPackageReference "NukeUI" */;
+			productName = NukeUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
Pulling this out of the big spankykong commit for future consideration. (I like the direction, but I don't really want to maintain multiple versions of the screen, and iOS 13 doesn't seem ready to drop just yet.)