### PR TITLE
Font support for Rounded added.

### DIFF
--- a/App/Composition/ComposeField.swift
+++ b/App/Composition/ComposeField.swift
@@ -12,13 +12,13 @@ final class ComposeField: UIView {
         super.init(frame: frame)
         
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: 16)
+        label.font = UIFont.preferredFontForTextStyle(.body, sizeAdjustment: -0.5, weight: .medium)
         label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
         addSubview(label)
         
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.font = UIFont.systemFont(ofSize: 16)
+        textField.font = UIFont.preferredFontForTextStyle(.body, sizeAdjustment: -0.5, weight: .regular)
         addSubview(textField)
         
         label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4).isActive = true

--- a/App/Composition/ComposeTextViewController.swift
+++ b/App/Composition/ComposeTextViewController.swift
@@ -292,7 +292,7 @@ class ComposeTextViewController: ViewController {
     override func loadView() {
         let textView = ComposeTextView()
         textView.restorationIdentifier = "ComposeTextView"
-        textView.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
+        textView.font = UIFont.preferredFontForTextStyle(.body, sizeAdjustment: -0.5, weight: .regular)
         textView.delegate = self
         view = textView
     }

--- a/App/Composition/CompositionViewController.swift
+++ b/App/Composition/CompositionViewController.swift
@@ -58,7 +58,7 @@ final class CompositionViewController: ViewController {
         super.themeDidChange()
         
         textView.textColor = theme["listTextColor"]
-        textView.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
+        textView.font = UIFont.preferredFontForTextStyle(.body, sizeAdjustment: -0.5, weight: .regular)
         textView.keyboardAppearance = theme.keyboardAppearance
         BBcodeBar?.keyboardAppearance = theme.keyboardAppearance
     }

--- a/App/Data Sources/ForumListDataSource.swift
+++ b/App/Data Sources/ForumListDataSource.swift
@@ -423,7 +423,7 @@ extension ForumListDataSource: UITableViewDataSource {
                 favoriteStar: announcement.hasBeenSeen ? .hidden : .isFavorite,
                 favoriteStarTintColor: theme["tintColor"]!,
                 forumName: NSAttributedString(string: announcement.title, attributes: [
-                    .font: UIFont.preferredFont(forTextStyle: .body),
+                    .font: UIFont.preferredFontForTextStyle(.body, fontName: theme["listFontName"], weight: .regular),
                     .foregroundColor: theme[color: "listTextColor"]!]),
                 indentationLevel: 0,
                 selectedBackgroundColor: theme["listSelectedBackgroundColor"]!)
@@ -436,7 +436,7 @@ extension ForumListDataSource: UITableViewDataSource {
                 favoriteStar: .isFavorite,
                 favoriteStarTintColor: theme["tintColor"]!,
                 forumName: NSAttributedString(string: forum.name ?? "", attributes: [
-                    .font: UIFont.preferredFont(forTextStyle: .body),
+                    .font: UIFont.preferredFontForTextStyle(.body, fontName: theme["listFontName"], weight: .regular),
                     .foregroundColor: theme[color: "listTextColor"]!]),
                 indentationLevel: 0,
                 selectedBackgroundColor: theme["listSelectedBackgroundColor"]!)
@@ -459,7 +459,7 @@ extension ForumListDataSource: UITableViewDataSource {
                 favoriteStar: forum.metadata.favorite ? .hidden : .canFavorite,
                 favoriteStarTintColor: theme["tintColor"]!,
                 forumName: NSAttributedString(string: forum.name ?? "", attributes: [
-                    .font: UIFont.preferredFont(forTextStyle: .body),
+                    .font: UIFont.preferredFontForTextStyle(.body, fontName: theme["listFontName"], weight: .regular),
                     .foregroundColor: theme[color: "listTextColor"]!]),
                 indentationLevel: forum.ancestors.reduce(0) { i, _ in i + 1 },
                 selectedBackgroundColor: theme["listSelectedBackgroundColor"]!)

--- a/App/Data Sources/MessageListDataSource.swift
+++ b/App/Data Sources/MessageListDataSource.swift
@@ -100,14 +100,14 @@ extension MessageListDataSource: UITableViewDataSource {
             backgroundColor: theme["listBackgroundColor"]!,
             selectedBackgroundColor: theme["listSelectedBackgroundColor"]!,
             sender: NSAttributedString(string: message.fromUsername ?? "", attributes: [
-                .font: UIFont.boldSystemFont(ofSize: UIFontDescriptor.preferredFontDescriptor(withTextStyle: UIFont.TextStyle.subheadline).pointSize),
-                .foregroundColor: theme[color: "listTextColor"]!]),
+                .font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: theme[double: "messageListSenderFontSizeAdjustment"]!, weight: .semibold),
+                .foregroundColor: theme[color: "listSecondaryTextColor"]!]),
             sentDate: message.sentDate ?? .distantPast,
             sentDateAttributes: [
-                .font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: -2),
+                .font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: theme[double: "messageListSentDateFontSizeAdjustment"]!, weight: .semibold),
                 .foregroundColor: theme[color: "listTextColor"]!],
             subject: NSAttributedString(string: message.subject ?? "", attributes: [
-                .font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: -2),
+                .font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: theme[double: "messageListSubjectFontSizeAdjustment"]!, weight: .regular),
                 .foregroundColor: theme[color: "listTextColor"]!]),
             tagImage: .image(name: message.threadTag?.imageName, placeholder: .privateMessage),
             tagOverlayImage: {

--- a/App/Data Sources/ThreadListDataSource.swift
+++ b/App/Data Sources/ThreadListDataSource.swift
@@ -149,7 +149,7 @@ extension ThreadListDataSource: UITableViewDataSource {
         return ThreadListCell.ViewModel(
             backgroundColor: theme["listBackgroundColor"]!,
             pageCount: NSAttributedString(string: "\(thread.numberOfPages)", attributes: [
-                .font: UIFont.preferredFontForTextStyle(.footnote, fontName: theme["listFontName"]),
+                .font: UIFont.preferredFontForTextStyle(.footnote, fontName: theme["listFontName"], sizeAdjustment: 0, weight: .semibold),
                 .foregroundColor: theme[color: "listSecondaryTextColor"]!]),
             pageIconColor: theme["threadListPageIconColor"]!,
             postInfo: {
@@ -161,7 +161,7 @@ extension ThreadListDataSource: UITableViewDataSource {
                     text = String(format: LocalizedString("thread-list.posted-by"), thread.author?.username ?? "")
                 }
                 return NSAttributedString(string: text, attributes: [
-                    .font: UIFont.preferredFontForTextStyle(.footnote, fontName: theme["listFontName"]),
+                    .font: UIFont.preferredFontForTextStyle(.footnote, fontName: theme["listFontName"], sizeAdjustment: 0, weight: .semibold),
                     .foregroundColor: theme[color: "listSecondaryTextColor"]!])
             }(),
             ratingImage: {
@@ -195,7 +195,7 @@ extension ThreadListDataSource: UITableViewDataSource {
                 }
             }(),
             title: NSAttributedString(string: thread.title ?? "", attributes: [
-                .font: UIFont.preferredFontForTextStyle(.body, fontName: theme["listFontName"]),
+                .font: UIFont.preferredFontForTextStyle(.body, fontName: theme["listFontName"], sizeAdjustment: 0, weight: .regular),
                 .foregroundColor: theme[color: thread.closed ? "listSecondaryTextColor" : "listTextColor"]!]),
             unreadCount: {
                 guard thread.beenSeen else { return NSAttributedString() }
@@ -214,7 +214,7 @@ extension ThreadListDataSource: UITableViewDataSource {
                     }
                 }
                 return NSAttributedString(string: "\(thread.unreadPosts)", attributes: [
-                    .font: UIFont.preferredFontForTextStyle(.caption1, fontName: theme["listFontName"], sizeAdjustment: 2),
+                    .font: UIFont.preferredFontForTextStyle(.caption1, fontName: theme["listFontName"], sizeAdjustment: 2, weight: .semibold),
                     .foregroundColor: color])
         }())
     }

--- a/App/Extensions/ChidoriMenuTableViewCell.swift
+++ b/App/Extensions/ChidoriMenuTableViewCell.swift
@@ -46,7 +46,7 @@ class ChidoriMenuTableViewCell: UITableViewCell {
         selectionStyle = .none
         accessibilityTraits = [.button]
 
-        menuTitleLabel.font = UIFont.systemFont(ofSize: 13, weight: .medium)
+        menuTitleLabel.font = UIFont.preferredFontForTextStyle(.body, fontName: nil, weight: .medium)
         menuTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         menuTitleLabel.numberOfLines = 0
         

--- a/App/Extensions/UIKit.swift
+++ b/App/Extensions/UIKit.swift
@@ -140,16 +140,25 @@ extension UIFont {
         - textStyle: The base style for the returned font.
         - fontName: An optional font name. If nil (the default), returns the system font.
         - sizeAdjustment: A positive or negative adjustment to apply to the text style's font size. The default is 0.
+        - weight: A positive or negative adjustment to apply to the text style's font size. The default is 0.
     - returns:
         A font associated with the text style, scaled for the user's Dynamic Type settings, in the requested font family.
     **/
-    class func preferredFontForTextStyle(_ textStyle: TypedTextStyle, fontName: String? = nil, sizeAdjustment: CGFloat = 0) -> UIFont {
-        let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: UIFont.TextStyle(rawValue: textStyle.UIKitRawValue))
+    class func preferredFontForTextStyle(_ textStyle: TextStyle, fontName: String? = nil, sizeAdjustment: CGFloat = 0, weight: UIFont.Weight) -> UIFont {
+        let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
+        let metrics = UIFontMetrics(forTextStyle: textStyle)
+        var font = metrics.scaledFont(for: UIFont.systemFont(ofSize: descriptor.pointSize + sizeAdjustment, weight: weight))
+        
         if let fontName = fontName {
             return UIFont(name: fontName, size: descriptor.pointSize + sizeAdjustment)!
         } else {
-            return UIFont(descriptor: descriptor, size: descriptor.pointSize + sizeAdjustment)
+            if let descriptor = UIFont.systemFont(ofSize: descriptor.pointSize + sizeAdjustment, weight: weight).fontDescriptor.withDesign(.rounded) {
+                if Theme.defaultTheme().roundedFonts {
+                    font = metrics.scaledFont(for: UIFont(descriptor: descriptor, size: descriptor.pointSize + sizeAdjustment))
+                }
+            }
         }
+        return font
     }
 }
 
@@ -193,9 +202,9 @@ extension UINavigationItem {
         label.accessibilityTraits.insert(UIAccessibilityTraits.header)
         switch UIDevice.current.userInterfaceIdiom {
         case .pad:
-            label.font = UIFont.systemFont(ofSize: 17)
+            label.font = UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: 0, weight: .regular)
         default:
-            label.font = UIFont.systemFont(ofSize: 13)
+            label.font = UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: -2, weight: .regular)
             label.numberOfLines = 2
         }
         titleView = label

--- a/App/In-App Actions/IconActionCell.swift
+++ b/App/In-App Actions/IconActionCell.swift
@@ -14,7 +14,7 @@ final class IconActionCell: UICollectionViewCell {
         iconImageView.contentMode = .center
         contentView.addSubview(iconImageView)
         
-        titleLabel.font = UIFont.systemFont(ofSize: 12)
+        titleLabel.font = UIFont.preferredFontForTextStyle(.body, sizeAdjustment: -2.5, weight: .medium)
         titleLabel.textColor = .white
         titleLabel.backgroundColor = .clear
         titleLabel.numberOfLines = 2

--- a/App/Navigation/NavigationBar.swift
+++ b/App/Navigation/NavigationBar.swift
@@ -31,7 +31,7 @@ final class NavigationBar: UINavigationBar {
         backIndicatorImage = UIImage(named: "back")
         backIndicatorTransitionMaskImage = UIImage(named: "back")
         
-        titleTextAttributes = [.font: UIFont.systemFont(ofSize: 17, weight: .regular)]
+        titleTextAttributes = [.font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: 0, weight: .regular)]
         
         addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(didLongPress)))
         

--- a/App/Navigation/NavigationController.swift
+++ b/App/Navigation/NavigationController.swift
@@ -104,7 +104,8 @@ final class NavigationController: UINavigationController, Themeable {
             appearance.backgroundColor = theme["navigationBarTintColor"]
             
             let textColor: UIColor? = theme["navigationBarTextColor"]
-            appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: textColor!]
+            appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: textColor!,
+                                              NSAttributedString.Key.font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: 0, weight: .semibold)]
             
             navigationBar.standardAppearance = appearance;
             navigationBar.scrollEdgeAppearance = navigationBar.standardAppearance

--- a/App/Theming/Themes.plist
+++ b/App/Theming/Themes.plist
@@ -55,6 +55,8 @@
 	</dict>
 	<key>default</key>
 	<dict>
+		<key>roundedFonts</key>
+		<false/>
 		<key>description</key>
 		<string>Light</string>
 		<key>descriptiveColor</key>
@@ -87,6 +89,12 @@
 			<string>#ffffff</string>
 			<key>listSelectedBackgroundColor</key>
 			<string>#cccccc</string>
+			<key>messageListSenderFontSizeAdjustment</key>
+			<integer>-2</integer>
+			<key>messageListSentDateFontSizeAdjustment</key>
+			<integer>-2</integer>
+			<key>messageListSubjectFontSizeAdjustment</key>
+			<integer>0</integer>
 			<key>threadListPageIconColor</key>
 			<string>#808080e5</string>
 		</dict>

--- a/App/Theming/Themes.swift
+++ b/App/Theming/Themes.swift
@@ -69,6 +69,11 @@ extension Theme {
         return dictionary["relevantForumID"] as! String?
     }
     
+    /// Does the theme use standed system font or rounded
+    var roundedFonts: Bool {
+        return dictionary["roundedFonts"] as? Bool ?? false
+    }
+    
     /// The desired appearance for the keyboard. If unspecified by the theme and its ancestors, returns .Default.
     var keyboardAppearance: UIKeyboardAppearance {
         let appearance = dictionary["keyboardAppearance"] as? String

--- a/App/View Controllers/Forums/ForumsTableViewController.swift
+++ b/App/View Controllers/Forums/ForumsTableViewController.swift
@@ -242,7 +242,7 @@ extension ForumsTableViewController {
 
         header.viewModel = .init(
             backgroundColor: theme["listHeaderBackgroundColor"],
-            font: UIFont.preferredFont(forTextStyle: .body),
+            font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: 0, weight: .regular),
             sectionName: listDataSource.titleForSection(section),
             textColor: theme["listHeaderTextColor"])
 

--- a/App/View Controllers/ImageViewController.swift
+++ b/App/View Controllers/ImageViewController.swift
@@ -138,11 +138,11 @@ final class ImageViewController: UIViewController {
             statusBarBackground.backgroundColor = overlaidBackgroundColor
             addSubview(statusBarBackground)
             
-            let bodyFontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: UIFont.TextStyle.body)
             let title = NSAttributedString(string: "Done", attributes: [
                 .foregroundColor: overlaidForegroundColor,
-                .font: UIFont.boldSystemFont(ofSize: bodyFontDescriptor.pointSize)
+                .font: UIFont.preferredFontForTextStyle(.body, weight: .bold)
                 ])
+
             doneButton.setAttributedTitle(title, for: UIControl.State())
             doneButton.contentEdgeInsets = UIEdgeInsets(top: 4, left: 6, bottom: 4, right: 6)
             doneButton.horizontalSlop = 10

--- a/App/View Controllers/Posts/PostsPageTopBar.swift
+++ b/App/View Controllers/Posts/PostsPageTopBar.swift
@@ -17,7 +17,7 @@ final class PostsPageTopBar: UIView {
         parentForumButton.accessibilityLabel = LocalizedString("posts-page.parent-forum-button.accessibility-label")
         parentForumButton.accessibilityHint = LocalizedString("posts-page.parent-forum-button.accessibility-hint")
         parentForumButton.setTitle(LocalizedString("posts-page.parent-forum-button.title"), for: .normal)
-        parentForumButton.titleLabel?.font = UIFont.systemFont(ofSize: 12)
+        parentForumButton.titleLabel?.font = UIFont.preferredFontForTextStyle(.body, sizeAdjustment: -2.5, weight: .regular)
         return parentForumButton
     }()
 
@@ -25,7 +25,7 @@ final class PostsPageTopBar: UIView {
         let previousPostsButton = UIButton(type: .system)
         previousPostsButton.accessibilityLabel = LocalizedString("posts-page.previous-posts-button.accessibility-label")
         previousPostsButton.setTitle(LocalizedString("posts-page.previous-posts-button.title"), for: .normal)
-        previousPostsButton.titleLabel?.font = UIFont.systemFont(ofSize: 12)
+        previousPostsButton.titleLabel?.font = UIFont.preferredFontForTextStyle(.body, sizeAdjustment: -2.5, weight: .regular)
         return previousPostsButton
     }()
 
@@ -33,7 +33,7 @@ final class PostsPageTopBar: UIView {
         let scrollToEndButton = UIButton(type: .system)
         scrollToEndButton.accessibilityLabel = LocalizedString("posts-page.scroll-to-end-button.accessibility-label")
         scrollToEndButton.setTitle(LocalizedString("posts-page.scroll-to-end-button.title"), for: .normal)
-        scrollToEndButton.titleLabel?.font = UIFont.systemFont(ofSize: 12)
+        scrollToEndButton.titleLabel?.font = UIFont.preferredFontForTextStyle(.body, sizeAdjustment: -2.5, weight: .regular)
         return scrollToEndButton
     }()
 

--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -546,6 +546,7 @@ final class PostsPageViewController: ViewController {
         if case .specific(let pageNumber)? = page, numberOfPages > 0 {
             currentPageItem.title = "\(pageNumber) / \(numberOfPages)"
             currentPageItem.accessibilityLabel = "Page \(pageNumber) of \(numberOfPages)"
+            currentPageItem.setTitleTextAttributes([.font: UIFont.preferredFontForTextStyle(.body, weight: .medium)], for: .normal)
         } else {
             currentPageItem.title = ""
             currentPageItem.accessibilityLabel = nil

--- a/App/View Controllers/Posts/Selectotron.swift
+++ b/App/View Controllers/Posts/Selectotron.swift
@@ -83,6 +83,7 @@ final class Selectotron : ViewController {
     public func updateJumpButtonTitle() {
         let title = .specific(selectedPage) == postsViewController.page ? "Reload" : "Jump"
         jumpButton.setTitle(title, for: .normal)
+        jumpButton.titleLabel?.font = UIFont.preferredFontForTextStyle(.body, weight: .medium)
     }
     
     fileprivate override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -112,7 +113,7 @@ extension Selectotron: UIPickerViewDataSource, UIPickerViewAccessibilityDelegate
     func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
         let attributes = [
             NSAttributedString.Key.foregroundColor: theme["sheetTextColor"]!,
-            .font: UIFont.preferredFont(forTextStyle: .body)
+            .font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: 0, weight: .regular)
         ]
         return NSAttributedString(string: "\(row + 1)", attributes: attributes)
     }

--- a/App/View Controllers/Settings/SettingsViewController.swift
+++ b/App/View Controllers/Settings/SettingsViewController.swift
@@ -322,6 +322,8 @@ final class SettingsViewController: TableViewController {
         
         cell.backgroundColor = theme["listBackgroundColor"]
         cell.textLabel?.textColor = theme["listTextColor"]
+        cell.textLabel?.font = UIFont.preferredFontForTextStyle(.body, fontName: theme["listFontName"], weight: .regular)
+        
         cell.selectedBackgroundColor = theme["listSelectedBackgroundColor"]
         
         if let switchView = cell.accessoryView as? UISwitch {

--- a/App/View Controllers/Thread Tags/SecondaryThreadTagPickerCell.swift
+++ b/App/View Controllers/Thread Tags/SecondaryThreadTagPickerCell.swift
@@ -42,7 +42,7 @@ final class SecondaryThreadTagPickerCell: UICollectionViewCell {
         
         let titleAttributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: titleTextColor,
-            .font: UIFont.systemFont(ofSize: 12)]
+            .font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: -2, weight: .regular)]
         let titleSize = titleText.size(withAttributes: titleAttributes)
         let titleOrigin = CGPoint(x: (bounds.width - titleSize.width) / 2, y: bounds.height - titleSize.height)
         let titleFrame = CGRect(origin: titleOrigin, size: titleSize)
@@ -59,7 +59,7 @@ final class SecondaryThreadTagPickerCell: UICollectionViewCell {
         let firstLetter = String(titleText.first ?? "?")
         let letterAttributes = [
             NSAttributedString.Key.foregroundColor: isSelected ? UIColor.white : drawColor,
-            .font: UIFont.systemFont(ofSize: 24)]
+            .font: UIFont.preferredFontForTextStyle(.body, fontName: nil, sizeAdjustment: 4, weight: .regular)]
         let letterSize = firstLetter.size(withAttributes: letterAttributes)
         let letterOrigin = CGPoint(
             x: circleFrame.midX - letterSize.width / 2,

--- a/App/View Controllers/Threads/ThreadPreviewViewController.swift
+++ b/App/View Controllers/Threads/ThreadPreviewViewController.swift
@@ -135,13 +135,13 @@ final class ThreadPreviewViewController: ViewController {
         threadCell.viewModel = ThreadListCell.ViewModel(
             backgroundColor: theme["listBackgroundColor"]!,
             pageCount: NSAttributedString(string: "1", attributes: [
-                .font: UIFont.preferredFontForTextStyle(.footnote, fontName: theme["listFontName"]),
+                .font: UIFont.preferredFontForTextStyle(.footnote, fontName: theme["listFontName"], weight: .regular),
                 .foregroundColor: theme[color: "listSecondaryTextColor"]!]),
             pageIconColor: theme["listSecondaryTextColor"]!,
             postInfo: {
                 let text = String(format: LocalizedString("compose.thread-preview.posting-in"), forum.name ?? "")
                 return NSAttributedString(string: text, attributes: [
-                    .font: UIFont.preferredFontForTextStyle(.footnote, fontName: theme["listFontName"]),
+                    .font: UIFont.preferredFontForTextStyle(.footnote, fontName: theme["listFontName"], weight: .regular),
                     .foregroundColor: theme[color: "listSecondaryTextColor"]!])
             }(),
             ratingImage: nil,
@@ -153,7 +153,7 @@ final class ThreadPreviewViewController: ViewController {
                 var subject = self.subject
                 subject.collapseWhitespace()
                 return NSAttributedString(string: subject, attributes: [
-                    .font: UIFont.preferredFontForTextStyle(.body, fontName: theme["listFontName"]),
+                    .font: UIFont.preferredFontForTextStyle(.body, fontName: theme["listFontName"], weight: .regular),
                     .foregroundColor: theme[color: "listTextColor"]!])
             }(),
             unreadCount: NSAttributedString())

--- a/App/View Controllers/Threads/ThreadsTableViewController.swift
+++ b/App/View Controllers/Threads/ThreadsTableViewController.swift
@@ -250,7 +250,7 @@ final class ThreadsTableViewController: TableViewController, ComposeTextViewCont
     private func updateFilterButton() {
         let title = LocalizedString(filterThreadTag == nil ? "thread-list.filter-button.no-filter" : "thread-list.filter-button.change-filter")
         filterButton.setTitle(title, for: .normal)
-        
+        filterButton.titleLabel?.font = UIFont.preferredFontForTextStyle(.body, sizeAdjustment: -2.5, weight: .medium)
         filterButton.tintColor = theme["tintColor"]
     }
     


### PR DESCRIPTION
Updated preferredFontForTextStyle to use rounded font design if enabled in the theme. This retains dynamic text sizing and allows for custom weight settings. 

Theme property roundedFonts added to default theme. 

Change this to YES to test rounded fonts. (Change it back to NO when done testing. SpankyKong themes will use this property) 

Updated instances of UIFont to use preferredFontForTextStyle.

After this change, dynamic text is applied in more places than before. Things should look largely the same in existing themes.