### PR TITLE
Allow additions to ignore list even while unremovable users present

### DIFF
--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -832,7 +832,7 @@ final class PostsPageViewController: ViewController {
             if self.selectedPost!.ignored {
                 let ignoreUser = UIAction.Identifier("ignoreUser")
                 actionMappings[ignoreUser] = ignoreUser(action:)
-                let ignoreAction = UIAction(title: "Ignore user",
+                let ignoreAction = UIAction(title: "Unignore user",
                                             image: UIImage(named: "ignore")!.withRenderingMode(.alwaysTemplate),
                                             identifier: ignoreUser,
                                             handler: ignoreUser(action:))
@@ -1179,8 +1179,11 @@ final class PostsPageViewController: ViewController {
         }
         
         self.dismiss(animated: false) {
+            // removing ignored users requires username. adding a new user requires userid
+            guard let userKey = self.selectedPost!.ignored ? self.selectedUser!.username : self.selectedUser!.userID else { return }
+            
             let ignoreBlock: (_ username: String) -> Promise<Void>
-            // TODO: this needs to toggle the menu between Ignore / Unignore
+            
             if self.selectedPost!.ignored {
                 ignoreBlock = ForumsClient.shared.removeUserFromIgnoreList
             } else {
@@ -1190,7 +1193,7 @@ final class PostsPageViewController: ViewController {
             let overlay = MRProgressOverlayView.showOverlayAdded(to: self.view, title: "Updating Ignore List", mode: .indeterminate, animated: true)
             overlay?.tintColor = self.theme["tintColor"]
             
-            ignoreBlock(self.selectedUser!.username!)
+            ignoreBlock(userKey)
                 .done {
                     overlay?.mode = .checkmark
                     

--- a/AwfulCore/Sources/AwfulCore/Scraping/IgnoreListChangeScrapeResult.swift
+++ b/AwfulCore/Sources/AwfulCore/Scraping/IgnoreListChangeScrapeResult.swift
@@ -31,8 +31,12 @@ public enum IgnoreListChangeScrapeResult: ScrapeResult {
         }
         else {
             do {
+                // responses to successfully adding a new ignorelist value differ depending on whether performed via profile page or ignore list page
+                let profileAddlistResponseMessage = "Your ignore list has been updated"
+                let ignorelistUpdatelistResponseMessage = "has now been successfully added to your ignore list"
+                
                 let inner = try html.requiredNode(matchingSelector: "div.inner")
-                if inner.textContent.contains("Your ignore list has been updated") {
+                if inner.textContent.contains(profileAddlistResponseMessage) || inner.textContent.contains(ignorelistUpdatelistResponseMessage){
                     self = .success
                 }
                 else {


### PR DESCRIPTION
- Function addUserToIgnoreList updated to take a userid and make POST to member2.php using parameters appropriate for the Profile (member.php) page.
- Fixed context menu to say "Ignore/Unignore user" conditionally
- Updated IgnoreListChangeScrapeResult.swift to add a success message produced by the forums. There's different text on the response page while adding an ignored user via profile vs ignore list

See:
https://forums.somethingawful.com/showthread.php?threadid=3910071&pagenumber=104#post528132223

Tested:
- Adding user to ignore list: OK
- Removing user from ignore list (which uses the same method as before): OK
- Adding a mod to the ignore list: Error as expected