### PR TITLE
Temporarily disabling composition text menu items that attempt imgur uploads

### DIFF
--- a/App/Composition/CompositionMenuTree.swift
+++ b/App/Composition/CompositionMenuTree.swift
@@ -192,7 +192,21 @@ fileprivate let rootItems = [
             tree.showSubmenu(URLItems)
         }
     }),
-    MenuItem(title: "[img]", action: { $0.showSubmenu(imageItems) }),
+    /**
+        Temporarily disabling the menu items that attempt image uploads. This is a bandaid fix and no imgur uploading code is being removed from the app at this time.
+        TODO: Re-enable these menu items as part of a proper imgur replacement update. (imgur is deleting anonymous inactive images)
+     
+        original line: MenuItem(title: "[img]", action: { $0.showSubmenu(imageItems) }),
+     */
+    MenuItem(title: "[img]", action: { tree in
+        if UIPasteboard.general.coercedURL == nil {
+            linkifySelection(tree)
+        } else {
+            if let textRange = tree.textView.selectedTextRange {
+                tree.textView.replace(textRange, withText:("[img]" + UIPasteboard.general.coercedURL!.absoluteString + "[/img]"))
+            }
+        }
+    }),
     MenuItem(title: "Format", action: { $0.showSubmenu(formattingItems) }),
     MenuItem(title: "[video]", action: { tree in
         if let URL = UIPasteboard.general.coercedURL {


### PR DESCRIPTION
Quick and dirty (I mean minimal and least disruptive) way to prevent imgur from being used is to remove the menu options.

This is a bandaid fix and the Anonymous imgur upload solution has not been touched in this PR. Actual removal and replacement can come in a later update.

It has been requested that this be addressed quickly as continued imgur uploads could impact the imgur link backup activities taking place by SA admins.

A temporary MenuItem for [img] has been created that will not enter a submenu, instead pasting a pasteboard url in img tags or wrap any selected text in img tags.