### PR TITLE
Stop registering defaults every time we render a post

### DIFF
--- a/App/View Controllers/Posts/PostRenderModel.swift
+++ b/App/View Controllers/Posts/PostRenderModel.swift
@@ -1,4 +1,4 @@
-//  PostViewModel.swift
+//  PostRenderModel.swift
 //
 //  Copyright 2016 Awful Contributors. CC BY-NC-SA 3.0 US https://github.com/Awful/Awful.app
 
@@ -40,7 +40,7 @@ struct PostRenderModel: StencilContextConvertible {
             }
             return true
         }
-        @FoilDefaultStorage(Settings.showAvatars) var showAvatars
+        var showAvatars: Bool { Awful.showAvatars }
         var hiddenAvatarURL: URL? {
             return showAvatars ? nil : post.author?.avatarURL
         }
@@ -103,12 +103,12 @@ private func massageHTML(_ html: String, isIgnored: Bool, forumID: String) -> St
     document.removeEmptyEditedByParagraphs()
     document.addAttributeToTweetLinks()
     document.useHTML5VimeoPlayer()
-    if let username = FoilDefaultStorageOptional(Settings.username).wrappedValue {
+    if let username = UserDefaults.standard.value(for: Settings.username) {
         document.identifyQuotesCitingUser(named: username, shouldHighlight: true)
         document.identifyMentionsOfUser(named: username, shouldHighlight: true)
     }
-    document.processImgTags(shouldLinkifyNonSmilies: !FoilDefaultStorage(Settings.loadImages).wrappedValue)
-    if !FoilDefaultStorage(Settings.autoplayGIFs).wrappedValue {
+    document.processImgTags(shouldLinkifyNonSmilies: !UserDefaults.standard.defaultingValue(for: Settings.loadImages))
+    if !UserDefaults.standard.defaultingValue(for: Settings.autoplayGIFs) {
         document.stopGIFAutoplay()
     }
     if isIgnored {
@@ -121,14 +121,14 @@ private func massageHTML(_ html: String, isIgnored: Bool, forumID: String) -> St
     return document.bodyElement?.innerHTML ?? ""
 }
 
- private var showAvatars: Bool {
-     FoilDefaultStorage(Settings.showAvatars).wrappedValue
+private var showAvatars: Bool {
+    UserDefaults.standard.defaultingValue(for: Settings.showAvatars)
 }
 
 private var enableCustomTitlePostLayout: Bool {
     switch UIDevice.current.userInterfaceIdiom {
     case .mac, .pad:
-        return FoilDefaultStorage(Settings.enableCustomTitlePostLayout).wrappedValue
+        return UserDefaults.standard.defaultingValue(for: Settings.enableCustomTitlePostLayout)
     default:
         return false
     }

--- a/Awful.xcodeproj/project.pbxproj
+++ b/Awful.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		1C16FBD51CBA91ED00C88BD1 /* PostsViewExternalStylesheetLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C16FBD41CBA91ED00C88BD1 /* PostsViewExternalStylesheetLoader.swift */; };
 		1C16FBD71CBAA00200C88BD1 /* PostsPageTopBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C16FBD61CBAA00200C88BD1 /* PostsPageTopBar.swift */; };
 		1C16FBD91CBAA33600C88BD1 /* PunishmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C16FBD81CBAA33600C88BD1 /* PunishmentCell.swift */; };
-		1C16FBE71CBC671A00C88BD1 /* PostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C16FBE61CBC671A00C88BD1 /* PostViewModel.swift */; };
+		1C16FBE71CBC671A00C88BD1 /* PostRenderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C16FBE61CBC671A00C88BD1 /* PostRenderModel.swift */; };
 		1C16FBF31CBDC58B00C88BD1 /* URL+OpensInBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C16FBF21CBDC58B00C88BD1 /* URL+OpensInBrowser.swift */; };
 		1C16FBF61CBDC65C00C88BD1 /* CaseInsensitiveMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C16FBF51CBDC65C00C88BD1 /* CaseInsensitiveMatching.swift */; };
 		1C16FBFC1CBF0F6B00C88BD1 /* ThreadTagPickerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C16FBFB1CBF0F6B00C88BD1 /* ThreadTagPickerCell.swift */; };
@@ -320,7 +320,7 @@
 		1C16FBD41CBA91ED00C88BD1 /* PostsViewExternalStylesheetLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostsViewExternalStylesheetLoader.swift; sourceTree = "<group>"; };
 		1C16FBD61CBAA00200C88BD1 /* PostsPageTopBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostsPageTopBar.swift; sourceTree = "<group>"; };
 		1C16FBD81CBAA33600C88BD1 /* PunishmentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PunishmentCell.swift; sourceTree = "<group>"; };
-		1C16FBE61CBC671A00C88BD1 /* PostViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostViewModel.swift; sourceTree = "<group>"; };
+		1C16FBE61CBC671A00C88BD1 /* PostRenderModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostRenderModel.swift; sourceTree = "<group>"; };
 		1C16FBF21CBDC58B00C88BD1 /* URL+OpensInBrowser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+OpensInBrowser.swift"; sourceTree = "<group>"; };
 		1C16FBF51CBDC65C00C88BD1 /* CaseInsensitiveMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaseInsensitiveMatching.swift; sourceTree = "<group>"; };
 		1C16FBFB1CBF0F6B00C88BD1 /* ThreadTagPickerCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadTagPickerCell.swift; sourceTree = "<group>"; };
@@ -724,7 +724,9 @@
 		1C29C382225853A300E1217A /* Posts */ = {
 			isa = PBXGroup;
 			children = (
+				2D265F8B292CB429001336ED /* GetOutFrogRefreshSpinnerView.swift */,
 				1C16FC191CD42EB300C88BD1 /* PostPreviewViewController.swift */,
+				1C16FBE61CBC671A00C88BD1 /* PostRenderModel.swift */,
 				1CFC99691BD3F402001180A7 /* PostsPageRefreshArrowView.swift */,
 				1CD0C54E1BE674D700C3AC80 /* PostsPageRefreshSpinnerView.swift */,
 				1C47AF4B19A790910098B828 /* PostsPageSettings.xib */,
@@ -732,11 +734,9 @@
 				1C16FBD61CBAA00200C88BD1 /* PostsPageTopBar.swift */,
 				1C16FC031CC3D84500C88BD1 /* PostsPageView.swift */,
 				1C0D7FFD1CF38CA2003EE2D1 /* PostsPageViewController.swift */,
-				1C16FBE61CBC671A00C88BD1 /* PostViewModel.swift */,
 				1CB15BFA1A9EC9C800176E73 /* ReportPostViewController.swift */,
 				1C82AC4A199F585000CB15FE /* Selectotron.swift */,
 				1C82AC4C199F5C1500CB15FE /* Selectotron.xib */,
-				2D265F8B292CB429001336ED /* GetOutFrogRefreshSpinnerView.swift */,
 			);
 			path = Posts;
 			sourceTree = "<group>";
@@ -1525,7 +1525,7 @@
 				1CEB5BFF19AB9C1700C82C30 /* InAppActionViewController.swift in Sources */,
 				1C16FBAA1CB5D38700C88BD1 /* CompositionInputAccessoryView.swift in Sources */,
 				1C9AEBCE210C3BAF00C9A567 /* main.swift in Sources */,
-				1C16FBE71CBC671A00C88BD1 /* PostViewModel.swift in Sources */,
+				1C16FBE71CBC671A00C88BD1 /* PostRenderModel.swift in Sources */,
 				1C6BDD22265CB307005475CE /* Imports.swift in Sources */,
 				1CB5F7F7201547D90046D080 /* Thread+Presentation.swift in Sources */,
 				1C16FC181CD1848400C88BD1 /* ComposeTextViewController.swift in Sources */,

--- a/AwfulSettings/Sources/AwfulSettings/UserDefaults+.swift
+++ b/AwfulSettings/Sources/AwfulSettings/UserDefaults+.swift
@@ -11,4 +11,15 @@ public extension UserDefaults {
     func value<T>(for setting: Setting<T>) -> T {
         value(forKey: setting.key) as! T
     }
+
+    /**
+     Returns the value for the setting, or the setting's default value.
+
+     Does not register the default. This is not usually the correct way to use UserDefaults, and you should prefer using either `AppStorage` or `FoilDefaultStorage` whenever possible, as those do register the default.
+
+     However, sometimes registering the default is a performance problem. That's when you go for this method.
+     */
+    func defaultingValue<T>(for setting: Setting<T>) -> T {
+        (value(forKey: setting.key) as! T?) ?? setting.default
+    }
 }


### PR DESCRIPTION
There's probably a nicer way to set all this up where we do register the default but like once per posts view. For now, we'll bypass registration.

Also rename the file that PostRenderModel is in to match its name.
