### PR TITLE
Parse youtube timestamps that contain 'm' and 's'

### DIFF
--- a/App/Misc/HTMLRenderingHelpers.swift
+++ b/App/Misc/HTMLRenderingHelpers.swift
@@ -438,26 +438,31 @@ private func randomwaffleURLForWaffleimagesURL(_ url: URL) -> URL? {
     return components.url
 }
 
+/**
+ Parse a "?t=" timestamp query param for a youtube video.  Returns the number of seconds, or nil.
+ 
+ Can optionally contain an "m" (minutes) and "s" (seconds)
+ 
+ Example inputs:
+    "5m3s" -> 303 (seconds)
+    "5m" -> 300 (seconds)
+    "99s" -> 99 (seconds)
+    "127" -> 127 (seconds)
+ */
 private func parseTimestampParam(t: String?) -> Int? {
-    if t == nil {
-        return nil
-    }
-    let tt = t ?? ""
-    let regex = try! NSRegularExpression(
-        pattern: "^(([0-9]*)m)?([0-9]*)s?",
-        options: .caseInsensitive)
-    if let results = regex.firstMatch(in: tt, range: NSRange(tt.startIndex..., in: tt)) {
-        let minsRange = Range(results.range(at: 2), in: tt)
-        let secsRange = Range(results.range(at: 3), in: tt)
-        let mins: Int? = if minsRange != nil { Int(tt[minsRange!]) } else { nil }
-        let secs: Int? = if secsRange != nil { Int(tt[secsRange!]) } else { nil }
-        if secs != nil {
-            let result = (mins ?? 0) * 60 + secs!
-            return result
+    if let tt = t?.replacingOccurrences(of: "s", with: "") {
+        if let mIndex = tt.firstIndex(of: "m") {
+            let beforeM = tt[tt.startIndex..<mIndex]
+            let mins = Int(beforeM)
+            let afterM = tt[tt.index(after: mIndex)...]
+            let secs = Int(afterM)
+            return (mins ?? 0) * 60 + (secs ?? 0)
+        } else {
+            return Int(tt)
         }
+    } else {
         return nil
     }
-    return nil
 }
 
 private func getYoutubeEmbeddedUri(href: String) -> URL? {

--- a/App/Misc/HTMLRenderingHelpers.swift
+++ b/App/Misc/HTMLRenderingHelpers.swift
@@ -438,6 +438,28 @@ private func randomwaffleURLForWaffleimagesURL(_ url: URL) -> URL? {
     return components.url
 }
 
+private func parseTimestampParam(t: String?) -> Int? {
+    if t == nil {
+        return nil
+    }
+    let tt = t ?? ""
+    let regex = try! NSRegularExpression(
+        pattern: "^(([0-9]*)m)?([0-9]*)s?",
+        options: .caseInsensitive)
+    if let results = regex.firstMatch(in: tt, range: NSRange(tt.startIndex..., in: tt)) {
+        let minsRange = Range(results.range(at: 2), in: tt)
+        let secsRange = Range(results.range(at: 3), in: tt)
+        let mins: Int? = if minsRange != nil { Int(tt[minsRange!]) } else { nil }
+        let secs: Int? = if secsRange != nil { Int(tt[secsRange!]) } else { nil }
+        if secs != nil {
+            let result = (mins ?? 0) * 60 + secs!
+            return result
+        }
+        return nil
+    }
+    return nil
+}
+
 private func getYoutubeEmbeddedUri(href: String) -> URL? {
     guard let source = URLComponents(string: href) else { return nil }
     let seconds: Int?
@@ -448,7 +470,7 @@ private func getYoutubeEmbeddedUri(href: String) -> URL? {
         seconds = source.queryItems?
             .first { $0.name == "t" }?
             .value
-            .flatMap { Int($0) }
+            .flatMap { parseTimestampParam(t: $0) }
     } else {
         id = source.queryItems?.first(where: { $0.name == "v" })?.value ?? ""
 
@@ -457,7 +479,7 @@ private func getYoutubeEmbeddedUri(href: String) -> URL? {
            pair.count == 2,
            pair[0] == "t"
         {
-            seconds = Int(pair[1])
+            seconds = parseTimestampParam(t: String(pair[1]))
         } else {
             seconds = nil
         }

--- a/App/Misc/HTMLRenderingHelpers.swift
+++ b/App/Misc/HTMLRenderingHelpers.swift
@@ -440,16 +440,16 @@ private func randomwaffleURLForWaffleimagesURL(_ url: URL) -> URL? {
 
 /**
  Parse a "?t=" timestamp query param for a youtube video.  Returns the number of seconds, or nil.
- 
+
  Can optionally contain an "m" (minutes) and "s" (seconds)
- 
+
  Example inputs:
     "5m3s" -> 303 (seconds)
     "5m" -> 300 (seconds)
     "99s" -> 99 (seconds)
     "127" -> 127 (seconds)
  */
-private func parseTimestampParam(t: String?) -> Int? {
+private func parseYoutubeTimestamp(t: String?) -> Int? {
     if let tt = t?.replacingOccurrences(of: "s", with: "") {
         if let mIndex = tt.firstIndex(of: "m") {
             let beforeM = tt[tt.startIndex..<mIndex]
@@ -475,7 +475,7 @@ private func getYoutubeEmbeddedUri(href: String) -> URL? {
         seconds = source.queryItems?
             .first { $0.name == "t" }?
             .value
-            .flatMap { parseTimestampParam(t: $0) }
+            .flatMap { parseYoutubeTimestamp(t: $0) }
     } else {
         id = source.queryItems?.first(where: { $0.name == "v" })?.value ?? ""
 
@@ -484,7 +484,7 @@ private func getYoutubeEmbeddedUri(href: String) -> URL? {
            pair.count == 2,
            pair[0] == "t"
         {
-            seconds = parseTimestampParam(t: String(pair[1]))
+            seconds = parseYoutubeTimestamp(t: String(pair[1]))
         } else {
             seconds = nil
         }


### PR DESCRIPTION
# Description

Fixes issue https://github.com/Awful/Awful.app/issues/1139

The current code supports only youtube URLs with a timestamp in the form of `?t={secs}`, and fails for timestamps such as `t={mins}m{secs}` and `t={mins}m{secs}s`.

I literally haven't thought about Swift since its 1.0 announcement so tell me how wrong my code is and I'll fix it.

## Unit tests?

I'd like to add some unit tests but would need to make the function non-private, or would need to test a few functions higher (`embedVideos()`). There doesn't seem to be a culture of heavy testing in this part of the code, let me know if you'd prefer tests.