### PR TITLE
Re-enable Imgur uploads. Adds options to disable, authenticate, or use anonymous uploads.

### DIFF
--- a/App/Extensions/ImgurAnonymousAPI+Shared.swift
+++ b/App/Extensions/ImgurAnonymousAPI+Shared.swift
@@ -1,33 +1,251 @@
 //  ImgurAnonymousAPI+Shared.swift
 //
-//  Copyright 2019 Awful Contributors. CC BY-NC-SA 3.0 US https://github.com/Awful/Awful.app
+//  Copyright 2025 Awful Contributors. CC BY-NC-SA 3.0 US https://github.com/Awful/Awful.app
 
 import Foundation
 import ImgurAnonymousAPI
+import UIKit
 import os
+import AwfulSettings
+import KeychainAccess
+import AuthenticationServices
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ImgurAnonymousAPI")
+// App-specific Imgur constants
+private enum AppImgurConstants {
+    static let clientID = "99240c4154dd0b4"
+}
 
-extension ImgurUploader {
-    static var shared: ImgurUploader {
-        return sharedUploader
+// MARK: - Imgur Auth Manager
+
+private let authLogger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ImgurAuthManager")
+
+/// Manager for handling Imgur authentication and token storage
+public final class ImgurAuthManager: NSObject, ImgurAuthProvider {
+    public static let shared = ImgurAuthManager()
+    
+    private let defaults = UserDefaults.standard
+    private var authSession: ASWebAuthenticationSession?
+    private var presentationContextProvider: PresentationContextProvider?
+    
+    private let keychain = Keychain(service: "com.awfulapp.Awful.imgur")
+    
+    private enum KeychainKeys {
+        static let bearerToken = "imgur_bearer_token"
+        static let refreshToken = "imgur_refresh_token"
+        static let tokenExpiry = "imgur_token_expiry"
+    }
+    
+    public enum DefaultsKeys {
+        static let rateLimited = "imgur_rate_limited"
+    }
+    
+    @FoilDefaultStorage(Settings.imgurUploadMode) private var imgurUploadMode
+    
+    private override init() {
+        super.init()
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleClearCredentialsNotification),
+            name: Notification.Name("ClearImgurCredentials"),
+            object: nil
+        )
+    }
+    
+    @objc private func handleClearCredentialsNotification() {
+        authLogger.info("Clearing Imgur credentials due to upload mode change")
+        logout()
+    }
+    
+    // MARK: - ImgurAuthProvider Protocol
+    
+    public var clientID: String {
+        return AppImgurConstants.clientID
+    }
+    
+    public var isAuthenticated: Bool {
+        return keychain[KeychainKeys.bearerToken] != nil
+    }
+    
+    public var currentUploadMode: String {
+        return imgurUploadMode.rawValue
+    }
+    
+    public var needsAuthentication: Bool {
+        return imgurUploadMode == .account && !isAuthenticated
+    }
+    
+    public var bearerToken: String? {
+        return keychain[KeychainKeys.bearerToken]
+    }
+    
+    /// Check if the token is expired and needs a refresh
+    public func checkTokenExpiry() -> Bool {
+        guard let expiryString = keychain[KeychainKeys.tokenExpiry],
+              let expiryTime = Double(expiryString) else {
+            return true // If no expiry time, assume expired
+        }
+        
+        // Check if the token is expired (with a 5-minute buffer)
+        let currentTime = Date().timeIntervalSince1970
+        return currentTime > (expiryTime - 300) // 5-minute buffer
+    }
+    
+    public func logout() {
+        do {
+            try keychain.remove(KeychainKeys.bearerToken)
+            try keychain.remove(KeychainKeys.refreshToken)
+            try keychain.remove(KeychainKeys.tokenExpiry)
+            authLogger.info("Cleared all Imgur authentication tokens from keychain")
+        } catch {
+            authLogger.error("Error clearing tokens from keychain: \(error.localizedDescription)")
+        }
+    }
+    
+    /// Start the authentication process
+    public func authenticate(from viewController: UIViewController, completion: @escaping (Bool) -> Void) {
+        guard let authURL = URL(string: "https://api.imgur.com/oauth2/authorize?client_id=\(clientID)&response_type=token&state=awful") else {
+            authLogger.error("Could not create Imgur OAuth URL")
+            completion(false)
+            return
+        }
+        
+        authLogger.debug("Starting authentication with URL: \(authURL.absoluteString)")
+        
+        let callbackURLScheme = "awful"
+        
+        guard let presentationAnchor = viewController.view.window else {
+            authLogger.error("Could not get presentation anchor for authentication")
+            completion(false)
+            return
+        }
+        
+        self.presentationContextProvider = PresentationContextProvider(anchor: presentationAnchor)
+        
+        authSession = ASWebAuthenticationSession(
+            url: authURL,
+            callbackURLScheme: callbackURLScheme
+        ) { [weak self] callbackURL, error in
+            guard let self = self else { return }
+            
+            if let error = error {
+                let errorString = error.localizedDescription
+                
+                if errorString.contains("cancelled") {
+                    authLogger.info("User cancelled Imgur authentication")
+                } else {
+                    authLogger.error("Imgur authentication failed: \(errorString)")
+                }
+                
+                completion(false)
+                return
+            }
+            
+            guard let callbackURL = callbackURL else {
+                authLogger.error("No callback URL received from Imgur")
+                completion(false)
+                return
+            }
+            
+            authLogger.debug("Received callback URL: \(callbackURL.absoluteString)")
+            
+            if let authError = ImgurOAuthResponse.checkForError(in: callbackURL) {
+                if case .rateLimited = authError {
+                    authLogger.error("Imgur rate limit exceeded")
+                    self.defaults.set(true, forKey: DefaultsKeys.rateLimited)
+                    // Set a timer to clear the rate limit flag after 1 hour
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 3600) {
+                        self.defaults.set(false, forKey: DefaultsKeys.rateLimited)
+                    }
+                } else {
+                    authLogger.error("Imgur authentication error: \(authError)")
+                    self.defaults.set(false, forKey: DefaultsKeys.rateLimited)
+                }
+                
+                completion(false)
+                return
+            }
+            
+            if let fragment = callbackURL.fragment, 
+               let response = ImgurOAuthResponse.parse(from: fragment) {
+                
+                self.keychain[KeychainKeys.bearerToken] = response.accessToken
+                self.keychain[KeychainKeys.refreshToken] = response.refreshToken
+                
+                let expiryTime = Date().timeIntervalSince1970 + response.expiresIn
+                self.keychain[KeychainKeys.tokenExpiry] = String(expiryTime)
+                
+                authLogger.info("Successfully authenticated with Imgur")
+                completion(true)
+            } else {
+                authLogger.error("Could not extract token information from callback URL")
+                completion(false)
+            }
+        }
+        
+        authSession?.presentationContextProvider = self.presentationContextProvider
+        authSession?.prefersEphemeralWebBrowserSession = true
+        
+        if !(authSession?.start() ?? false) {
+            authLogger.error("Failed to start Imgur authentication session")
+            completion(false)
+        }
     }
 }
 
-private let sharedUploader: ImgurUploader = {
-    ImgurUploader.logger = { level, message in
-        let otherLevel: OSLogType
-        switch level {
-        case .debug:
-            otherLevel = .debug
-        case .info:
-            otherLevel = .info
-        case .error:
-            otherLevel = .error
-        }
-        let message = message()
-        logger.log(level: otherLevel, "\(message)")
+private class PresentationContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private let anchor: ASPresentationAnchor
+    
+    init(anchor: ASPresentationAnchor) {
+        self.anchor = anchor
+        super.init()
     }
     
-    return ImgurUploader(clientID: "4db466addcb5cfc")
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return anchor
+    }
+}
+
+// MARK: - Imgur Uploader Configuration
+
+private let uploaderLogger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ImgurUploaderConfig")
+
+extension ImgurUploader {
+    static var shared: ImgurUploader {
+        let imgurUploadMode = ImgurAuthManager.shared.currentUploadMode
+        
+        if imgurUploadMode == "Imgur Account", ImgurAuthManager.shared.isAuthenticated {
+            uploaderLogger.debug("Using authenticated Imgur uploader with bearer token")
+            return authenticatedUploader
+        }
+        
+        uploaderLogger.debug("Using anonymous Imgur uploader")
+        return anonymousUploader
+    }
+    
+    private static var authenticatedUploader: ImgurUploader = {
+        let uploader = ImgurUploader(authProvider: ImgurAuthManager.shared)
+        configureLogger(for: uploader)
+        return uploader
+    }()
+}
+
+private let anonymousUploader: ImgurUploader = {
+    let uploader = ImgurUploader(authProvider: ImgurAuthManager.shared)
+    configureLogger(for: uploader)
+    return uploader
 }()
+
+private func configureLogger(for uploader: ImgurUploader) {
+    ImgurUploader.logger = { level, messageProvider in
+        let message = messageProvider()
+        switch level {
+        case .debug:
+            uploaderLogger.debug("\(message)")
+        case .info:
+            uploaderLogger.info("\(message)")
+        case .error:
+            uploaderLogger.error("\(message)")
+        }
+    }
+}

--- a/Awful.xcodeproj/project.pbxproj
+++ b/Awful.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		2D327DD627F468CE00D21AB0 /* BookmarkColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D327DD527F468CE00D21AB0 /* BookmarkColorPicker.swift */; };
 		2D921269292F588100B16011 /* platinum-member.png in Resources */ = {isa = PBXBuildFile; fileRef = 2D921268292F588100B16011 /* platinum-member.png */; };
 		2DD8209C25DDD9BF0015A90D /* CopyImageActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD8209B25DDD9BF0015A90D /* CopyImageActivity.swift */; };
+		306F740B2D90AA01000717BC /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 306F740A2D90AA01000717BC /* KeychainAccess */; };
 		83410EF219A582B8002CD019 /* DateFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83410EF119A582B8002CD019 /* DateFormatters.swift */; };
 		8C0F4F561682CCFA00E25D7E /* macinyos-heading-center.png in Resources */ = {isa = PBXBuildFile; fileRef = 8C0F4F541682CCFA00E25D7E /* macinyos-heading-center.png */; };
 		8C0F4F571682CCFA00E25D7E /* macinyos-heading-right.png in Resources */ = {isa = PBXBuildFile; fileRef = 8C0F4F551682CCFA00E25D7E /* macinyos-heading-right.png */; };
@@ -581,6 +582,7 @@
 				1C725A8926E71C6D009713DC /* MRProgress in Frameworks */,
 				1C53451E2B8BF3A7001DA96A /* PSMenuItem in Frameworks */,
 				1C47122A2664CB8000E5AA74 /* Smilies in Frameworks */,
+				306F740B2D90AA01000717BC /* KeychainAccess in Frameworks */,
 				1C5345212B8BF48F001DA96A /* ScrollViewDelegateMultiplexer in Frameworks */,
 				1C67313C2B55CE0600A8CF6F /* AwfulSettingsUI in Frameworks */,
 				1CB0B9AB2AEF668500678615 /* NukeExtensions in Frameworks */,
@@ -1286,6 +1288,7 @@
 				1C1F0F152B8B0AD700F097D3 /* AwfulTheming */,
 				1C53451D2B8BF3A7001DA96A /* PSMenuItem */,
 				1C5345202B8BF48F001DA96A /* ScrollViewDelegateMultiplexer */,
+				306F740A2D90AA01000717BC /* KeychainAccess */,
 			);
 			productName = Awful;
 			productReference = 1D6058910D05DD3D006BFB54 /* AwfulDebug.app */;
@@ -1352,6 +1355,7 @@
 				1CD72E65265C7FD600FF3BF4 /* XCRemoteSwiftPackageReference "FLAnimatedImage" */,
 				1C6B2A98272F992E00671F0C /* XCRemoteSwiftPackageReference "Nuke" */,
 				2D265F8D292CB447001336ED /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				306F74092D90AA01000717BC /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
@@ -1900,6 +1904,14 @@
 				minimumVersion = 4.0.0;
 			};
 		};
+		306F74092D90AA01000717BC /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kishikawakatsumi/KeychainAccess";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.2.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1983,6 +1995,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2D265F8D292CB447001336ED /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
+		};
+		306F740A2D90AA01000717BC /* KeychainAccess */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 306F74092D90AA01000717BC /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+			productName = KeychainAccess;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Awful.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Awful.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "KeychainAccess",
+        "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess",
+        "state": {
+          "branch": null,
+          "revision": "84e546727d66f1adc5439debad16270d0fdd04e7",
+          "version": "4.2.2"
+        }
+      },
+      {
         "package": "Lottie",
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {

--- a/AwfulSettings/Sources/AwfulSettings/Settings.swift
+++ b/AwfulSettings/Sources/AwfulSettings/Settings.swift
@@ -65,6 +65,9 @@ public enum Settings {
     /// Make the device vibrate when certain things happen.
     public static let enableHaptics = Setting(key: "enable_haptics", default: false)
 
+    /// Mode for Imgur image uploads (Off, Anonymous, or with Account)
+    public static let imgurUploadMode = Setting(key: "imgur_upload_mode", default: ImgurUploadMode.default)
+
     /// What percentage to multiply the default post font size by. Stored as percentage points, i.e. default is `100` aka "100% size" aka the default.
     public static let fontScale = Setting(key: "font_scale", default: 100.0)
 
@@ -144,6 +147,16 @@ public enum BuiltInTheme: String, UserDefaultsSerializable {
     case winpos95 = "Winpos 95"
     case yosposAmber = "YOSPOS (amber)"
     case yosposGreen = "YOSPOS"
+}
+
+/// The upload mode for Imgur images.
+public enum ImgurUploadMode: String, CaseIterable, UserDefaultsSerializable {
+    // These raw values are persisted in user defaults, so don't change them willy nilly.
+    case off = "Off"
+    case anonymous = "Anonymous"
+    case account = "Imgur Account"
+    
+    static var `default`: Self { .off }
 }
 
 /// The default browser set by the user via `UserDefaults` and `Settings.defaultBrowser`.

--- a/AwfulSettingsUI/Package.resolved
+++ b/AwfulSettingsUI/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "foil",
+      "kind" : "remoteSourceControl",
+      "location" : "http://github.com/jessesquires/Foil",
+      "state" : {
+        "revision" : "ff4b49d2e7852f876ded552fb596e510a66670b9",
+        "version" : "5.1.2"
+      }
+    },
+    {
+      "identity" : "htmlreader",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nolanw/HTMLReader",
+      "state" : {
+        "revision" : "d4003bf59feead2361f684a372123eae0afe104f",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "lottie-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/lottie-ios.git",
+      "state" : {
+        "revision" : "047aa81b77adcbf583a966dfef620d17650cc656",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke",
+      "state" : {
+        "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
+        "version" : "12.8.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/AwfulSettingsUI/Sources/AwfulSettingsUI/Localizable.xcstrings
+++ b/AwfulSettingsUI/Sources/AwfulSettingsUI/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "\"Anonymous\" submits images to Imgur without a user account. Imgur may delete these uploads without warning. Using an Imgur account is recommended." : {
+
+    },
     "[timg] Large Images" : {
 
     },
@@ -11,6 +14,9 @@
 
     },
     "Always Preview New Posts" : {
+
+    },
+    "Anonymous" : {
 
     },
     "App Icon" : {
@@ -103,6 +109,12 @@
     "Hide Sidebar in Landscape" : {
 
     },
+    "Imgur Account" : {
+
+    },
+    "Imgur Uploads" : {
+
+    },
     "Links" : {
 
     },
@@ -113,6 +125,9 @@
 
     },
     "Logging out erases all cached forums, threads, and posts." : {
+
+    },
+    "Off" : {
 
     },
     "Open Twitter in Twitter" : {

--- a/AwfulSettingsUI/Sources/AwfulSettingsUI/SettingsView.swift
+++ b/AwfulSettingsUI/Sources/AwfulSettingsUI/SettingsView.swift
@@ -33,6 +33,7 @@ public struct SettingsView: View {
     @AppStorage(Settings.bookmarksSortedUnread) private var sortFirstUnreadBookmarks
     @AppStorage(Settings.forumThreadsSortedUnread) private var sortFirstUnreadThreads
     @AppStorage(Settings.automaticTimg) private var timgLargeImages
+    @AppStorage("imgur_upload_mode") private var imgurUploadMode: String = "Off"
 
     let appIconDataSource: AppIconDataSource
     let avatarURL: URL?
@@ -158,9 +159,22 @@ public struct SettingsView: View {
 
             Section {
                 Toggle("[timg] Large Images", bundle: .module, isOn: $timgLargeImages)
+                Picker("Imgur Uploads", bundle: .module, selection: $imgurUploadMode) {
+                    Text("Off").tag("Off")
+                    Text("Imgur Account").tag("Imgur Account")
+                    Text("Anonymous").tag("Anonymous")
+                }
+                .onChange(of: imgurUploadMode) { newValue in
+                    if newValue != "Imgur Account" {
+                        clearImgurCredentials()
+                    }
+                }
             } header: {
                 Text("Posting", bundle: .module)
                     .header()
+            } footer: {
+                Text("\"Anonymous\" submits images to Imgur without a user account. Imgur may delete these uploads without warning. Using an Imgur account is recommended.", bundle: .module)
+                    .footer()
             }
             .section()
 
@@ -296,6 +310,10 @@ public struct SettingsView: View {
         .tint(theme[color: "tint"]!)
         .backport.scrollContentBackground(.hidden)
         .background(theme[color: "background"]!)
+    }
+
+    private func clearImgurCredentials() {
+        NotificationCenter.default.post(name: Notification.Name("ClearImgurCredentials"), object: nil)
     }
 }
 

--- a/ImgurAnonymousAPI/README.md
+++ b/ImgurAnonymousAPI/README.md
@@ -1,6 +1,7 @@
 # ImgurAnonymousAPI
 
-Uploads images "anonymously" (i.e. unassociated with an account) using version 3 of the Imgur API.
+Uploads images to Imgur using version 3 of the Imgur API
+Orignally this library only supported anonymous uploads (hence, the name). It's been extended to support authenticated uploads.
 
 This project is focused on taking an image in an app and uploading it to Imgur. It has no interest in providing a full-featured Imgur API client. Because the scope is so narrow, we can make the functionality we do offer as comfortable as possible:
 
@@ -9,6 +10,7 @@ This project is focused on taking an image in an app and uploading it to Imgur. 
 * We cheerfully resize that gigantic image until it ducks below the Imgur file size limit.
 * We resize that gigantic image without getting you terminated for eating all the device's memory.
 * We depend only on Foundation and ImageIO (and optionally Photos and/or UIKit, as available).
+* We now support both anonymous and authenticated uploads through Imgur's OAuth2 flow.
 
 ## Getting started
 
@@ -18,7 +20,9 @@ Next step is to get a copy of this library. We support Carthage, CocoaPods, and 
 
 Check out the included test application to see if this library will work with your images. To run that, open `ImgurAnonymousAPI.xcodeproj` and run the "iOSTestApp" scheme. (If you run into code signing issues, be sure to set your development team in the "iOSTestApp" target settings under the General tab in the Signing section.)
 
-Here's an image picker-based example, assuming you've already got your image picker showing up:
+### Anonymous Uploads Example
+
+Here's an image picker-based example for anonymous uploads, assuming you've already got your image picker showing up:
 
 ```swift
 import ImgurAnonymousAPI
@@ -47,13 +51,78 @@ class ViewController: UIImagePickerControllerDelegate {
 }
 ```
 
+### Authenticated Uploads
+
+This library now supports authenticated uploads using Imgur's OAuth2 flow. This has several advantages:
+
+* Higher rate limits
+* Images are associated with the user's Imgur account
+* Better management of uploaded images
+
+To use authenticated uploads, you need to:
+
+1. Register your application with Imgur and obtain a client ID
+2. Configure a custom URL scheme for your app that will be used as the callback URL
+3. Use the `ImgurAuthManager` class to handle the authentication flow
+
+Here's an example of how to set up authenticated uploads:
+
+```swift
+import ImgurAnonymousAPI
+import AuthenticationServices
+
+class MyViewController: UIViewController {
+    
+    private let authManager = ImgurAuthManager.shared
+    
+    @IBAction func authenticateWithImgur() {
+        // Start the authentication flow
+        authManager.authenticate(from: self) { success in
+            if success {
+                // User successfully authenticated
+                print("Imgur authentication successful!")
+                
+                // Now you can use the authenticated uploader
+                let uploader = ImgurUploader(clientID: "my-client-id", 
+                                           bearerToken: authManager.bearerToken)
+                
+                // Upload an image...
+            } else {
+                // Authentication failed
+                print("Imgur authentication failed")
+            }
+        }
+    }
+    
+    // When you're ready to upload an image
+    func uploadImageWithAuthentication(_ image: UIImage) {
+        // Get the appropriate uploader based on authentication status
+        let uploader = authManager.isAuthenticated 
+            ? ImgurUploader(clientID: "my-client-id", bearerToken: authManager.bearerToken) 
+            : ImgurUploader(clientID: "my-client-id")
+            
+        uploader.upload(image, completion: { result in
+            switch result {
+            case .success(let response):
+                print("Image uploaded to \(response.link)")
+            case .failure(let error):
+                print("Upload failed: \(error)")
+            }
+        })
+    }
+}
+```
+
 ## Notes and caveats
 
-* The Imgur API has various rate limits in place. This library lets you keep track of that rate limiting, and you should probably pay attention at least to the "client" limits, as exeeceding them too often can get your API key banned for the rest of the month.
+* The Imgur API has various rate limits in place. This library lets you keep track of that rate limiting, and you should probably pay attention at least to the "client" limits, as exceeding them too often can get your API key banned for the rest of the month.
+* Authenticated uploads have higher rate limits than anonymous uploads.
 * Animated images are not fully supported. We will attempt to upload them, but they are not resized to fit under the maximum file size limit.
 * To upload an animated image from an image picker, be sure to request photo library authorization from your user before showing the image picker. (This library won't prompt the user for you.)
 * This library will never attempt to use the photo library unless the user has already authorized its use. This library will never trigger a photo library authorization prompt. And this library will never trigger a crash due to a missing `Info.plist` value for the key `NSPhotoLibraryUsageDescription` (remember that, as of iOS 11, you can have the user pick a photo without requiring authorization).
-* Continuing the theme of anonymous image uploads, we use our own URL session with an ephemeral configuration.
+* For anonymous uploads, we use our own URL session with an ephemeral configuration.
+* For authenticated uploads, you'll need to securely store the OAuth tokens. The example `ImgurAuthManager` uses Keychain for this purpose.
+* The authentication flow uses `ASWebAuthenticationSession` which requires iOS 12 or later.
 
 ## Development
 

--- a/ImgurAnonymousAPI/Sources/ImgurAnonymousAPI/ImageOperations.swift
+++ b/ImgurAnonymousAPI/Sources/ImgurAnonymousAPI/ImageOperations.swift
@@ -100,6 +100,8 @@ internal final class ResizeImage: AsynchronousOperation<ImageFile>, @unchecked S
                     kCGImageSourceCreateThumbnailWithTransform: true,
                     kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
                     kCGImageSourceShouldCache: false] as NSDictionary),
+
+                // This was originally kUTTypeTIFF in an attempt to preserve rotation data, but modern Imgur was rejecting tiff files. :-/
                 let destination = CGImageDestinationCreateWithURL(resizedImageURL as CFURL, CGImageSourceGetType(imageSource) ?? kUTTypePNG, 1, nil) else
             {
                 log(.error, "thumbnail creation failed")
@@ -246,14 +248,13 @@ internal final class SaveUIImage: AsynchronousOperation<ImageFile>, @unchecked S
     
     private func saveStatic() throws -> URL {
         let tempFolder = try firstDependencyValue(ofType: TemporaryFolder.self)
-        let imageURL = tempFolder.url.appendingPathComponent("original.tiff", isDirectory: false)
+        let imageURL = tempFolder.url.appendingPathComponent("original.png", isDirectory: false)
 
         guard let cgImage = image.cgImage else {
             throw ImageError.missingCGImage
         }
 
-        // Save as TIFF here to preserve orientation data (unlike PNG) with lossless image data (unlike JPEG).
-        guard let destination = CGImageDestinationCreateWithURL(imageURL as CFURL, kUTTypeTIFF, 1, nil) else {
+        guard let destination = CGImageDestinationCreateWithURL(imageURL as CFURL, kUTTypePNG, 1, nil) else {
             throw ImageError.destinationCreationFailed
         }
 

--- a/ImgurAnonymousAPI/Sources/ImgurAnonymousAPI/ImgurAuthInterface.swift
+++ b/ImgurAnonymousAPI/Sources/ImgurAnonymousAPI/ImgurAuthInterface.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Protocol defining the common interface for Imgur authentication
+public protocol ImgurAuthProvider {
+    /// Returns the current bearer token for authenticated requests, if available
+    var bearerToken: String? { get }
+    
+    /// Returns true if the user is authenticated
+    var isAuthenticated: Bool { get }
+    
+    /// Clears authentication credentials
+    func logout()
+    
+    /// Returns the client ID to use for API requests
+    var clientID: String { get }
+}
+
+/// Constants related to Imgur API responses
+public enum ImgurAuthError: Error {
+    /// Rate limit exceeded (429 Too Many Requests)
+    case rateLimited
+    
+    /// Authentication failed
+    case authenticationFailed
+    
+    /// User cancelled authentication
+    case userCancelled
+    
+    /// Invalid client ID
+    case invalidClientID
+    
+    /// Generic error
+    case other(String)
+}
+
+/// Helper for parsing Imgur OAuth responses
+@available(iOS 13.0, macOS 10.15, *)
+public struct ImgurOAuthResponse {
+    public let accessToken: String
+    public let refreshToken: String
+    public let expiresIn: TimeInterval
+    
+    /// Parse an OAuth callback URL fragment into a structured response
+    public static func parse(from fragment: String) -> ImgurOAuthResponse? {
+        let fragmentComponents = fragment
+            .components(separatedBy: "&")
+            .map { $0.components(separatedBy: "=") }
+            .filter { $0.count == 2 }
+            .reduce(into: [String: String]()) { result, pair in
+                result[pair[0]] = pair[1]
+            }
+        
+        if let accessToken = fragmentComponents["access_token"],
+           let expiresInString = fragmentComponents["expires_in"],
+           let expiresIn = TimeInterval(expiresInString),
+           let refreshToken = fragmentComponents["refresh_token"] {
+            return ImgurOAuthResponse(
+                accessToken: accessToken,
+                refreshToken: refreshToken,
+                expiresIn: expiresIn
+            )
+        }
+        
+        return nil
+    }
+    
+    /// Check if a URL indicates an error response
+    public static func checkForError(in url: URL) -> ImgurAuthError? {
+        if url.absoluteString.contains("error=") {
+            // Extract error information
+            if let fragment = url.fragment, fragment.contains("error=") {
+                let fragmentParts = fragment.components(separatedBy: "&")
+                var errorMessage = "Unknown error"
+                
+                for part in fragmentParts {
+                    if part.hasPrefix("error=") {
+                        errorMessage = part.replacingOccurrences(of: "error=", with: "")
+                        errorMessage = errorMessage.removingPercentEncoding ?? errorMessage
+                    }
+                }
+                
+                // Map error messages to specific error types
+                if errorMessage.contains("429") || errorMessage.contains("Too Many Requests") {
+                    return .rateLimited
+                } else if errorMessage.contains("cancel") || errorMessage.contains("cancelled") {
+                    return .userCancelled
+                } else if errorMessage.contains("invalid_client") {
+                    return .invalidClientID
+                }
+                
+                return .other(errorMessage)
+            }
+            
+            // Check query parameters for errors
+            if let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems {
+                for item in queryItems where item.name == "error" {
+                    let errorMessage = item.value ?? "Unknown error"
+                    
+                    if errorMessage.contains("429") || errorMessage.contains("Too Many Requests") {
+                        return .rateLimited
+                    } else if errorMessage.contains("cancel") || errorMessage.contains("cancelled") {
+                        return .userCancelled
+                    } else if errorMessage.contains("invalid_client") {
+                        return .invalidClientID
+                    }
+                    
+                    return .other(errorMessage)
+                }
+            }
+        }
+        
+        return nil
+    }
+} 


### PR DESCRIPTION
Adds some settings to allow users to keep images off, use their own damn Imgur account, or live dangerously and use anonymouse Auth.

*Note*
I did have to update the clientID to my own. This is because you have to set the redirect url in the app registration.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/deb2268e-a610-4efc-b0d9-e7080b275618" />

If you want me to set it back, I can. But we'll need to make sure the callback url is set to `awful://imgur-callback`

Here are some screenshots:
![Simulator Screenshot - iPhone 16 Pro - 2025-03-23 at 15 56 05](https://github.com/user-attachments/assets/3c81f53e-9c8a-4eff-b0f4-3ba2454043a6)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-30 at 19 03 55](https://github.com/user-attachments/assets/a45e694f-655a-4ef6-a894-6b3401ecb173)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-30 at 19 04 18](https://github.com/user-attachments/assets/b76f6fb6-cb3d-4f49-9db9-07f79e4b36d1)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-30 at 19 20 20](https://github.com/user-attachments/assets/ba45c0fe-9ed3-4c29-9f48-0e938e6e2096)




