### PR TITLE
iPad/macOS polish: toolbar bottom padding, scene restoration depth, nav-bar shadow, end-of-thread frog

### DIFF
--- a/App/Main/AppDelegate.swift
+++ b/App/Main/AppDelegate.swift
@@ -174,6 +174,21 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func open(route: AwfulRoute) {
         urlRouter?.route(route)
     }
+
+    /// Overload that threads scene-restoration payloads through to the router so a
+    /// freshly-constructed `PostsPageViewController` / `MessageViewController` can stage
+    /// its restored scroll fraction (and hidden-posts count) before its first render.
+    func open(
+        route: AwfulRoute,
+        pendingPostsRestoration: PendingPostsRestoration? = nil,
+        pendingMessageRestoration: PendingMessageRestoration? = nil
+    ) {
+        urlRouter?.route(
+            route,
+            pendingPostsRestoration: pendingPostsRestoration,
+            pendingMessageRestoration: pendingMessageRestoration
+        )
+    }
     
     private func updateShortcutItems() {
         guard urlRouter != nil else {

--- a/App/Main/RootViewControllerStack.swift
+++ b/App/Main/RootViewControllerStack.swift
@@ -154,14 +154,45 @@ final class RootViewControllerStack: NSObject, AwfulSplitViewControllerDelegate 
         firstVisibleViewController { ($0 as? RestorableLocation)?.restorationRoute }
     }
 
-    /// Topmost visible `PostsPageViewController`, used by `SceneDelegate` to apply restored
-    /// scroll fraction and hidden-posts state after the URL router has pushed a fresh instance.
+    /// Route identifying the currently selected sidebar tab's root VC. Saved by `SceneDelegate`
+    /// so the sidebar tab is restored independently of whatever detail thread/message the
+    /// primary route captured. On iPad/macOS the detail pane and the sidebar tab are
+    /// orthogonal — the primary route records the detail, this records the tab.
+    var currentSidebarTabRoute: AwfulRoute? {
+        guard let rootNav = tabBarController.selectedViewController as? UINavigationController,
+              let root = rootNav.viewControllers.first as? RestorableLocation
+        else { return nil }
+        return root.restorationRoute
+    }
+
+    /// Route for the deepest `RestorableLocation` pushed on top of the selected tab's root
+    /// (e.g. `.forum(id:)` for a `ThreadsTableViewController` pushed under `ForumsTableViewController`).
+    /// Saved by `SceneDelegate` so that cold-launch restoration rebuilds the mid-stack
+    /// navigation depth — without this, restoring a thread detail would land the user back on
+    /// the forum list instead of the specific forum's thread list they had drilled into.
+    /// Returns nil when the primary nav has only the tab root (redundant with
+    /// `currentSidebarTabRoute`).
+    var currentPrimaryDeepRoute: AwfulRoute? {
+        guard let nav = tabBarController.selectedViewController as? UINavigationController else { return nil }
+        let stack = nav.viewControllers
+        guard stack.count > 1 else { return nil }
+        for vc in stack.reversed() {
+            if vc === stack.first { break }
+            if let route = (vc as? RestorableLocation)?.restorationRoute {
+                return route
+            }
+        }
+        return nil
+    }
+
+    /// Topmost visible `PostsPageViewController`, used by `SceneDelegate` to read the current
+    /// scroll fraction and hidden-posts count when building the scene's restoration activity.
     var topPostsPageViewController: PostsPageViewController? {
         firstVisibleViewController { $0 as? PostsPageViewController }
     }
 
-    /// Topmost visible `MessageViewController`, used by `SceneDelegate` to apply a restored
-    /// scroll fraction after the URL router has pushed a fresh instance.
+    /// Topmost visible `MessageViewController`, used by `SceneDelegate` to read the current
+    /// scroll fraction when building the scene's restoration activity.
     var topMessageViewController: MessageViewController? {
         firstVisibleViewController { $0 as? MessageViewController }
     }

--- a/App/Main/SceneDelegate.swift
+++ b/App/Main/SceneDelegate.swift
@@ -31,6 +31,21 @@ private let restorationHiddenPostsKey = "AwfulRestorationHiddenPosts"
 /// primary `NavigationController`, encoded as an array of `AwfulRoute.httpURL` strings.
 private let restorationUnpopRoutesKey = "AwfulRestorationUnpopRoutes"
 
+/// `NSUserActivity.userInfo` key carrying the selected sidebar tab's root route (e.g.
+/// `.forumList` / `.bookmarks` / `.messagesList` / `.settings`), encoded as its `httpURL`
+/// string. On iPad/macOS the detail pane and the sidebar tab are orthogonal: the primary
+/// route captures the detail thread/message, this captures which tab the sidebar was on.
+/// On iPhone this records the tab the primary navigation stack was rooted at, which we
+/// re-select on replay before pushing the detail route so `showPostsViewController` lands
+/// in the right tab's nav stack.
+private let restorationSidebarTabKey = "AwfulRestorationSidebarTab"
+
+/// `NSUserActivity.userInfo` key carrying the deepest non-root `RestorableLocation` on the
+/// selected tab's navigation stack (e.g. `.forum(id:)` when the user had drilled into a
+/// specific forum's thread list). Replayed between the sidebar tab selection and the detail
+/// route so the mid-stack view (thread list) is rebuilt before the leaf (thread detail).
+private let restorationPrimaryDeepRouteKey = "AwfulRestorationPrimaryDeepRoute"
+
 /// `UserDefaults` key for a fallback copy of the scene's most recent restoration activity.
 ///
 /// iOS only calls `stateRestorationActivity(for:)` when the scene is actually disconnected
@@ -96,11 +111,25 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Save the UserDefaults fallback on `willResignActive` as well as on
+        // `didEnterBackground`, to narrow the race where Xcode's Stop-the-process arrives
+        // before `didEnterBackground` is delivered asynchronously (and on iPad some Home
+        // paths can leave the scene in `foregroundInactive` without ever reaching
+        // `background`). `willResignActive` runs synchronously on the main queue as part
+        // of the resign transition, so we catch the state earlier.
+        snapshotFallback(for: scene)
+    }
+
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Snapshot the current restoration activity to UserDefaults as a fallback for the cases
         // where iOS doesn't get a chance to call `stateRestorationActivity(for:)` itself (Xcode
         // Stop, crash while backgrounded). Scene disconnect will still go through the regular
         // path and overwrite whatever UIKit persists on `session.stateRestorationActivity`.
+        snapshotFallback(for: scene)
+    }
+
+    private func snapshotFallback(for scene: UIScene) {
         if let activity = stateRestorationActivity(for: scene) {
             saveFallbackRestorationActivity(activity)
         } else {
@@ -141,14 +170,55 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let savedUnpopRoutes = (activity.userInfo?[restorationUnpopRoutesKey] as? [String])?
                 .compactMap(URL.init(string:))
                 .compactMap { try? AwfulRoute($0) } ?? []
+            let savedTabRoute = (activity.userInfo?[restorationSidebarTabKey] as? String)
+                .flatMap(URL.init(string:))
+                .flatMap { try? AwfulRoute($0) }
+            let savedPrimaryDeepRoute = (activity.userInfo?[restorationPrimaryDeepRouteKey] as? String)
+                .flatMap(URL.init(string:))
+                .flatMap { try? AwfulRoute($0) }
             DispatchQueue.main.async {
-                AppDelegate.instance.open(route: route)
-                guard let stack = AppDelegate.instance.rootViewControllerStackIfLoaded else { return }
-                if let topPosts = stack.topPostsPageViewController {
-                    topPosts.prepareForRestoration(scrollFraction: savedFraction, hiddenPosts: savedHiddenPosts)
-                } else if let topMessage = stack.topMessageViewController, let fraction = savedFraction {
-                    topMessage.prepareForRestoration(scrollFraction: fraction)
+                // Select the sidebar tab FIRST so the detail-route push (below) lands in
+                // the correct context: on iPad `showPostsViewController` pushes into the
+                // detail nav regardless, but the sidebar's visible tab needs to match;
+                // on iPhone the detail route pushes onto the selected tab's nav, so the
+                // tab must already be correct before we open the detail route.
+                if let tabRoute = savedTabRoute, tabRoute.httpURL != route.httpURL {
+                    AppDelegate.instance.open(route: tabRoute)
                 }
+                // Then rebuild the mid-stack primary navigation depth (e.g. the specific
+                // forum's thread list the user had drilled into) BEFORE pushing the detail
+                // route, so the primary nav ends up as [tabRoot, midStack] on iPad, or
+                // [tabRoot, midStack, detail] on iPhone when `showPostsViewController` then
+                // pushes the detail onto the selected tab's nav.
+                if let primaryDeepRoute = savedPrimaryDeepRoute,
+                   primaryDeepRoute.httpURL != route.httpURL,
+                   primaryDeepRoute.httpURL != savedTabRoute?.httpURL
+                {
+                    AppDelegate.instance.open(route: primaryDeepRoute)
+                }
+                // Stage any scroll-fraction / hidden-posts payload through the router so
+                // the freshly-constructed `PostsPageViewController` / `MessageViewController`
+                // applies it before its first render. Doing this after `open(route:)` returns
+                // is too late on iPad, where the cached render can fire WKWebView callbacks
+                // before we get a chance to call `prepareForRestoration`.
+                switch route {
+                case .threadPage, .threadPageSingleUser:
+                    AppDelegate.instance.open(
+                        route: route,
+                        pendingPostsRestoration: PendingPostsRestoration(
+                            scrollFraction: savedFraction,
+                            hiddenPosts: savedHiddenPosts
+                        )
+                    )
+                case .message:
+                    AppDelegate.instance.open(
+                        route: route,
+                        pendingMessageRestoration: savedFraction.map { PendingMessageRestoration(scrollFraction: $0) }
+                    )
+                default:
+                    AppDelegate.instance.open(route: route)
+                }
+                guard let stack = AppDelegate.instance.rootViewControllerStackIfLoaded else { return }
                 if !savedUnpopRoutes.isEmpty, let primaryNav = stack.currentPrimaryNavigationController {
                     let context = AppDelegate.instance.managedObjectContext
                     let restoredVCs = savedUnpopRoutes.compactMap { makeUnpopViewController(for: $0, in: context) }
@@ -194,6 +264,14 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         else { return nil }
         let activity = NSUserActivity(activityType: restorationActivityType)
         activity.addUserInfoEntries(from: [restorationPrimaryRouteKey: route.httpURL.absoluteString])
+        if let tabRoute = stack.currentSidebarTabRoute {
+            activity.addUserInfoEntries(from: [restorationSidebarTabKey: tabRoute.httpURL.absoluteString])
+        }
+        if let primaryDeepRoute = stack.currentPrimaryDeepRoute,
+           primaryDeepRoute.httpURL != route.httpURL
+        {
+            activity.addUserInfoEntries(from: [restorationPrimaryDeepRouteKey: primaryDeepRoute.httpURL.absoluteString])
+        }
         if let topPosts = stack.topPostsPageViewController {
             var extras: [AnyHashable: Any] = [restorationHiddenPostsKey: topPosts.currentHiddenPosts]
             if let fraction = topPosts.currentScrollFraction {

--- a/App/Navigation/NavigationController.swift
+++ b/App/Navigation/NavigationController.swift
@@ -634,9 +634,6 @@ final class NavigationController: UINavigationController, Themeable {
 
     @available(iOS 26.0, *)
     private func configureBackground(for appearance: UINavigationBarAppearance, progress: CGFloat) {
-        appearance.shadowColor = nil
-        appearance.shadowImage = nil
-
         if progress < ScrollProgress.atTop {
             appearance.configureWithOpaqueBackground()
             appearance.backgroundColor = theme["navigationBarTintColor"]
@@ -660,6 +657,12 @@ final class NavigationController: UINavigationController, Themeable {
                 appearance.backgroundColor = interpolateColor(from: opaqueColor, to: gradientBaseColor, progress: progress)
             }
         }
+
+        // Must be set AFTER configureWith* — those methods reset shadow state
+        // back to system defaults, which renders as a grey hairline on dark
+        // themes (most visible on SpankyKongDark) once scrolled off the top.
+        appearance.shadowColor = .clear
+        appearance.shadowImage = nil
     }
 
     @available(iOS 26.0, *)

--- a/App/URLs/AwfulURLRouter.swift
+++ b/App/URLs/AwfulURLRouter.swift
@@ -9,6 +9,22 @@ import CoreData
 import MRProgress
 import UIKit
 
+/// Scroll fraction and hidden-posts state staged by scene-restoration for an incoming
+/// `.threadPage` / `.threadPageSingleUser` route. Applied to the freshly-constructed
+/// `PostsPageViewController` before its view renders, so the restored offset survives the
+/// initial cached-render window (which on iPad would otherwise fire `didFinishRenderingHTML`
+/// with no fraction staged).
+struct PendingPostsRestoration {
+    let scrollFraction: CGFloat?
+    let hiddenPosts: Int?
+}
+
+/// Scroll fraction staged by scene-restoration for an incoming `.message` route. Applied to
+/// the freshly-constructed `MessageViewController` before its view renders.
+struct PendingMessageRestoration {
+    let scrollFraction: CGFloat
+}
+
 /// Translates URLs with the scheme "awful" into an appropriate shown screen.
 struct AwfulURLRouter {
 
@@ -27,12 +43,16 @@ struct AwfulURLRouter {
     
     /// Show the screen appropriate for an "awful" URL.
     @discardableResult
-    func route(_ route: AwfulRoute) -> Bool {
-        
+    func route(
+        _ route: AwfulRoute,
+        pendingPostsRestoration: PendingPostsRestoration? = nil,
+        pendingMessageRestoration: PendingMessageRestoration? = nil
+    ) -> Bool {
+
         if enableHaptics {
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
         }
-        
+
         switch route {
         case .bookmarks:
             return selectTopmostViewController(containingViewControllerOfClass: BookmarksTableViewController.self) != nil
@@ -56,7 +76,7 @@ struct AwfulURLRouter {
 
             let key = PrivateMessageKey(messageID: messageID)
             if let message = PrivateMessage.existingObjectForKey(objectKey: key, in: managedObjectContext) {
-                inbox.showMessage(message)
+                inbox.showMessage(message, pendingRestoration: pendingMessageRestoration)
                 return true
             }
 
@@ -68,7 +88,7 @@ struct AwfulURLRouter {
                 do {
                     let message = try await ForumsClient.shared.readPrivateMessage(identifiedBy: key)
                     overlay.dismiss(true, completion: {
-                        inbox.showMessage(message)
+                        inbox.showMessage(message, pendingRestoration: pendingMessageRestoration)
                     })
                 } catch {
                     overlay.titleLabelText = "Message Not Found"
@@ -160,10 +180,10 @@ struct AwfulURLRouter {
             return selectTopmostViewController(containingViewControllerOfClass: SettingsViewController.self) != nil
 
         case let .threadPage(threadID: threadID, page: page, updateSeen):
-            return showThread(threadID, page: page, updateSeen: updateSeen)
+            return showThread(threadID, page: page, updateSeen: updateSeen, pendingRestoration: pendingPostsRestoration)
 
         case let .threadPageSingleUser(threadID: threadID, userID: userID, page: page, updateSeen):
-            return showThread(threadID, page: page, justPostsByUser: userID, updateSeen: updateSeen)
+            return showThread(threadID, page: page, justPostsByUser: userID, updateSeen: updateSeen, pendingRestoration: pendingPostsRestoration)
         }
     }
     
@@ -210,19 +230,20 @@ struct AwfulURLRouter {
         _ threadID: String,
         page: ThreadPage,
         justPostsByUser userID: String? = nil,
-        updateSeen: AwfulRoute.UpdateSeen
+        updateSeen: AwfulRoute.UpdateSeen,
+        pendingRestoration: PendingPostsRestoration? = nil
     ) -> Bool {
         let threadKey = ThreadKey(threadID: threadID)
-        let thread = AwfulThread.objectForKey(objectKey: threadKey, in: managedObjectContext) 
+        let thread = AwfulThread.objectForKey(objectKey: threadKey, in: managedObjectContext)
         let postsVC: PostsPageViewController
         if let userID = userID, !userID.isEmpty {
             let userKey = UserKey(userID: userID, username: nil)
-            let user = User.objectForKey(objectKey: userKey, in: managedObjectContext) 
+            let user = User.objectForKey(objectKey: userKey, in: managedObjectContext)
             postsVC = PostsPageViewController(thread: thread, author: user)
         } else {
             postsVC = PostsPageViewController(thread: thread)
         }
-        
+
         try! managedObjectContext.save()
 
         var updateLastRead: Bool {
@@ -232,7 +253,19 @@ struct AwfulURLRouter {
             }
         }
         postsVC.loadPage(page, updatingCache: true, updatingLastReadPost: updateLastRead)
-        
+
+        // Stage the restored scroll fraction / hiddenPosts inside the same synchronous
+        // run-loop turn as `loadPage`, so the cached-render path (which fires WKWebView
+        // callbacks on a subsequent main-queue tick) sees the staged values. Doing this
+        // here instead of after `open(route:)` returns closes the iPad race where
+        // `didFinishRenderingHTML` could fire with `scrollToFractionAfterLoading == nil`.
+        if let pending = pendingRestoration {
+            postsVC.prepareForRestoration(
+                scrollFraction: pending.scrollFraction,
+                hiddenPosts: pending.hiddenPosts
+            )
+        }
+
         return showPostsViewController(postsVC)
     }
     

--- a/App/View Controllers/Messages/MessageListViewController.swift
+++ b/App/View Controllers/Messages/MessageListViewController.swift
@@ -109,11 +109,14 @@ final class MessageListViewController: TableViewController {
         }
     }
     
-    func showMessage(_ message: PrivateMessage) {
+    func showMessage(_ message: PrivateMessage, pendingRestoration: PendingMessageRestoration? = nil) {
         if enableHaptics {
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
         }
         let viewController = MessageViewController(privateMessage: message)
+        if let pending = pendingRestoration {
+            viewController.prepareForRestoration(scrollFraction: pending.scrollFraction)
+        }
         showDetailViewController(viewController, sender: self)
     }
 

--- a/App/View Controllers/Posts/PostsPageView.swift
+++ b/App/View Controllers/Posts/PostsPageView.swift
@@ -289,9 +289,18 @@ final class PostsPageView: UIView {
 
         if toolbar.transform == .identity {
             let toolbarHeight = toolbar.sizeThatFits(bounds.size).height
+            // On iPad / Mac (Designed for iPad), the system safe area at the
+            // bottom can be 0 (windowed multitasking, Catalyst), which would
+            // pin the toolbar flush against the window's bottom edge. Enforce
+            // a minimum bottom inset so the toolbar reads as aligned with the
+            // sidebar's RootTabBar instead of disappearing off the bottom.
+            let minimumPadBottomInset: CGFloat = 28
+            let effectiveBottomInset: CGFloat = traitCollection.userInterfaceIdiom == .pad
+                ? max(layoutMargins.bottom, minimumPadBottomInset)
+                : layoutMargins.bottom
             toolbar.frame = CGRect(
                 x: bounds.minX + layoutMargins.left,
-                y: bounds.maxY - layoutMargins.bottom - toolbarHeight,
+                y: bounds.maxY - effectiveBottomInset - toolbarHeight,
                 width: bounds.width - layoutMargins.left - layoutMargins.right,
                 height: toolbarHeight)
         }

--- a/App/View Controllers/Posts/PostsPageView.swift
+++ b/App/View Controllers/Posts/PostsPageView.swift
@@ -76,10 +76,17 @@ final class PostsPageView: UIView {
                         ])
                     }
                     if refreshControl is GetOutFrogRefreshSpinnerView {
+                        // Horizontal anchors use PostsPageView's layoutMarginsGuide so the
+                        // frog centers within the visible detail column on iPad/macOS
+                        // (accounting for the sidebar's safe-area inset), rather than within
+                        // the full scroll-view width. PostsPageViewController keeps
+                        // postsView.layoutMargins synced with view.safeAreaInsets, so on
+                        // iPhone these margins are zero and centering is unchanged.
                         NSLayoutConstraint.activate([
-                            refreshControl.leftAnchor.constraint(equalTo: containerMargins.leftAnchor),
-                            containerMargins.rightAnchor.constraint(equalTo: refreshControl.rightAnchor),
-                            containerMargins.bottomAnchor.constraint(equalTo: refreshControl.bottomAnchor)
+                            refreshControl.leftAnchor.constraint(equalTo: layoutMarginsGuide.leftAnchor),
+                            layoutMarginsGuide.rightAnchor.constraint(equalTo: refreshControl.rightAnchor),
+                            containerMargins.bottomAnchor.constraint(equalTo: refreshControl.bottomAnchor),
+                            refreshControl.heightAnchor.constraint(equalToConstant: 110)
                         ])
                     }
                 }


### PR DESCRIPTION
## Summary

Four iPad/macOS and dark-theme fixes that together smooth out detail-pane layout and state restoration.

- **Bottom toolbar alignment** (`PostsPageView`): enforce a minimum 28pt bottom inset on iPad so the toolbar stays aligned with the sidebar's RootTabBar in Catalyst / windowed multitasking contexts where the system safe-area inset is 0.

- **Scene restoration depth**: the scene's restoration activity now captures (a) the selected sidebar tab and (b) the deepest mid-stack `RestorableLocation` on the primary nav (e.g. the specific forum's thread list the user had drilled into). On cold launch, replay selects the tab → rebuilds the mid-stack → pushes the detail route, so thread restoration lands the user back where they were instead of at the forums root.

- **Pre-render restoration staging**: scroll-fraction and hidden-posts payloads are now threaded through `AwfulURLRouter` into the freshly-constructed `PostsPageViewController` / `MessageViewController` before `loadPage` returns, closing the iPad race where `didFinishRenderingHTML` could fire from the cached-render path before `prepareForRestoration` was called.

- **Extra fallback snapshot** on `sceneWillResignActive` — catches the Xcode-Stop / iPad-Home paths that can skip `sceneDidEnterBackground`.

- **SpankyKongDark nav-bar hairline**: in the iOS 26 appearance path, clear `shadowColor` / `shadowImage` AFTER `configureWithOpaqueBackground` / `configureWithTransparentBackground` (which reset them to system defaults), so the grey hairline no longer appears under the nav bar on scroll on dark themes.

- **End-of-thread frog** (`GetOutFrogRefreshSpinnerView`): switch horizontal anchors to PostsPageView.layoutMarginsGuide` and pin the height to 110pt so the frog centers within the visible detail column on iPad/macOS (respecting the sidebar's safe-area inset) and has room to land at its intended size. iPhone layout is unchanged (postsView margins are 0).