### PR TITLE
Hide Post Metadata from Screen Reader

### DIFF
--- a/App/Resources/RenderView.js
+++ b/App/Resources/RenderView.js
@@ -1612,6 +1612,23 @@ Awful.setShowAvatars = function(showAvatars) {
 
 
 /**
+ Toggles aria-hidden on post metadata so iOS Spoken Content / VoiceOver skips usernames, regdates, and post dates.
+
+ @param {boolean} hide - `true` to mark the post header and post date as aria-hidden, `false` to restore them.
+ */
+Awful.setHidePostMetadataForReader = function(hide) {
+  var els = document.querySelectorAll('post > header, post > footer');
+  Array.prototype.forEach.call(els, function(el) {
+    if (hide) {
+      el.setAttribute('aria-hidden', 'true');
+    } else {
+      el.removeAttribute('aria-hidden');
+    }
+  });
+};
+
+
+/**
  Updates the stylesheet for the currently-selected theme.
 
  @param {string} css - The replacement stylesheet from the new theme.

--- a/App/Templates/Post.html.stencil
+++ b/App/Templates/Post.html.stencil
@@ -7,6 +7,7 @@
 
     <header
         class="userid-{{ author.userID|htmlEscape }} {% if customTitleHTML %} responsive {% endif %}"
+        {% if hideMetadataForReader %} aria-hidden="true" {% endif %}
         {% if hiddenAvatarURL %} data-awful-avatar="{{ hiddenAvatarURL|htmlEscape }}" {% endif %}>
 
         {% if visibleAvatarURL and not customTitleHTML %}
@@ -42,7 +43,7 @@
         {{ htmlContents }}
     </section>
 
-	<footer>
+	<footer {% if hideMetadataForReader %} aria-hidden="true" {% endif %}>
         <span class="divider{% if beenSeen %} divider-seen {% endif %}"></span>
         <span class="postdate">
             {% if postDateRaw %}

--- a/App/View Controllers/Posts/PostRenderModel.swift
+++ b/App/View Controllers/Posts/PostRenderModel.swift
@@ -68,6 +68,7 @@ struct PostRenderModel: StencilContextConvertible {
             "beenSeen": post.beenSeen,
             "customTitleHTML": (enableCustomTitlePostLayout ? post.author?.customTitleHTML : nil) as Any,
             "hiddenAvatarURL": hiddenAvatarURL as Any,
+            "hideMetadataForReader": hidePostMetadataForReader,
             "htmlContents": htmlContents,
             "postDate": post.postDate as Any,
             "postDateRaw": postDateRaw as String,
@@ -77,7 +78,7 @@ struct PostRenderModel: StencilContextConvertible {
             "showRegdate": showRegdate,
             "visibleAvatarURL": visibleAvatarURL as Any]
     }
-    
+
     init(author: User, isOP: Bool, postDate: String, postHTML: String) {
         context = [
             "author": [
@@ -86,6 +87,7 @@ struct PostRenderModel: StencilContextConvertible {
                 "username": author.username as Any],
             "beenSeen": false,
             "hiddenAvatarURL": (showAvatars ? author.avatarURL : nil) as Any,
+            "hideMetadataForReader": hidePostMetadataForReader,
             "customTitleHTML": (enableCustomTitlePostLayout ? author.customTitleHTML : nil) as Any,
             "htmlContents": massageHTML(postHTML, isIgnored: false, forumID: ""),
             "postDate": postDate,
@@ -124,6 +126,10 @@ private func massageHTML(_ html: String, isIgnored: Bool, forumID: String) -> St
 
 private var showAvatars: Bool {
     UserDefaults.standard.defaultingValue(for: Settings.showAvatars)
+}
+
+private var hidePostMetadataForReader: Bool {
+    UserDefaults.standard.defaultingValue(for: Settings.hidePostMetadataForReader)
 }
 
 private var enableCustomTitlePostLayout: Bool {

--- a/App/View Controllers/Posts/PostsPageViewController.swift
+++ b/App/View Controllers/Posts/PostsPageViewController.swift
@@ -33,6 +33,7 @@ final class PostsPageViewController: ViewController {
     @FoilDefaultStorage(Settings.fontScale) private var fontScale
     @FoilDefaultStorage(Settings.frogAndGhostEnabled) private var frogAndGhostEnabled
     @FoilDefaultStorage(Settings.handoffEnabled) private var handoffEnabled
+    @FoilDefaultStorage(Settings.hidePostMetadataForReader) private var hidePostMetadataForReader
     private var jumpToLastPost = false
     @FoilDefaultStorageOptional(Settings.lastOfferedPasteboardURLString) private var lastOfferedPasteboardURLString
     @FoilDefaultStorageOptional(Settings.userID) private var loggedInUserID
@@ -1898,6 +1899,12 @@ final class PostsPageViewController: ViewController {
                     self.configureUserActivityIfPossible()
                 }
             }
+            .store(in: &cancellables)
+
+        $hidePostMetadataForReader
+            .dropFirst()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.postsView.renderView.setHidePostMetadataForReader($0) }
             .store(in: &cancellables)
 
         $pullForNext

--- a/App/Views/RenderView.swift
+++ b/App/Views/RenderView.swift
@@ -800,6 +800,17 @@ extension RenderView {
         }
     }
     
+    /// Marks (when `true`) or unmarks (when `false`) post header and footer with `aria-hidden="true"` so iOS Spoken Content / VoiceOver skip them.
+    func setHidePostMetadataForReader(_ hide: Bool) {
+        Task {
+            do {
+                try await webView.eval("if (window.Awful) Awful.setHidePostMetadataForReader(\(hide ? "true" : "false"))")
+            } catch {
+                self.mentionError(error, explanation: "could not evaluate setHidePostMetadataForReader")
+            }
+        }
+    }
+
     /// Turns all avatars on (when `true`) or off (when `false`).
     func setShowAvatars(_ showAvatars: Bool) {
         Task {

--- a/AwfulSettings/Sources/AwfulSettings/Settings.swift
+++ b/AwfulSettings/Sources/AwfulSettings/Settings.swift
@@ -86,6 +86,9 @@ public enum Settings {
     /// Offer to hand off the current thread page to other devices.
     public static let handoffEnabled = Setting(key: "handoff_enabled", default: false)
 
+    /// Mark post header (username, regdate, role labels) and post date as `aria-hidden` so iOS Spoken Content / VoiceOver skip them and read post bodies more directly.
+    public static let hidePostMetadataForReader = Setting(key: "hide_post_metadata_for_reader", default: false)
+
     /// Hide the sidebar in landscape orientation (assuming the display is wide enough to show the sidebar at all).
     public static let hideSidebarInLandscape = Setting(key: "hide_sidebar_in_landscape", default: false)
 

--- a/AwfulSettingsUI/Sources/AwfulSettingsUI/Localizable.xcstrings
+++ b/AwfulSettingsUI/Sources/AwfulSettingsUI/Localizable.xcstrings
@@ -118,6 +118,9 @@
     "Handoff allows you to continue reading threads on nearby devices." : {
 
     },
+    "Hide Post Metadata from Screen Reader" : {
+
+    },
     "Hide Sidebar in Landscape" : {
 
     },
@@ -179,6 +182,9 @@
 
     },
     "Sidebar" : {
+
+    },
+    "Skips usernames, post dates, and join dates when iOS reads posts aloud (Speak Screen and VoiceOver)." : {
 
     },
     "Sort Unread Bookmarks First" : {

--- a/AwfulSettingsUI/Sources/AwfulSettingsUI/SettingsView.swift
+++ b/AwfulSettingsUI/Sources/AwfulSettingsUI/SettingsView.swift
@@ -23,6 +23,7 @@ public struct SettingsView: View {
     @AppStorage(Settings.fontScale) private var fontScale
     @AppStorage(Settings.frogAndGhostEnabled) private var frogAndGhostEnabled
     @AppStorage(Settings.handoffEnabled) private var handoffEnabled
+    @AppStorage(Settings.hidePostMetadataForReader) private var hidePostMetadataForReader
     @AppStorage(Settings.hideSidebarInLandscape) private var hideSidebarInLandscape
     @AppStorage(Settings.immersiveModeEnabled) private var immersiveModeEnabled
     @AppStorage(Settings.loadImages) private var loadImages
@@ -157,9 +158,13 @@ public struct SettingsView: View {
                 if isPad {
                     Toggle("Enable Custom Title Post Layout", bundle: .module, isOn: $customTitlePostLayout)
                 }
+                Toggle("Hide Post Metadata from Screen Reader", bundle: .module, isOn: $hidePostMetadataForReader)
             } header: {
                 Text("Posts", bundle: .module)
                     .header()
+            } footer: {
+                Text("Skips usernames, post dates, and join dates when iOS reads posts aloud (Speak Screen and VoiceOver).", bundle: .module)
+                    .footer()
             }
             .section()
 


### PR DESCRIPTION
New setting that adds aria-hidden to usernames, join dates, post actions, posted dates. Thread title, post contents, quotes are all read aloudwhile additional elements are dropped. Two-finger pull from top brings up Screen Reader. Will also apply to Voiceover if the setting is enabled, but Voiceover remains unaffected otherwise.

Tested on my actual device, works well.

Requested: https://forums.somethingawful.com/showthread.php?noseen=1&threadid=3837546&pagenumber=216&perpage=40&highlight=swipe,down#post548636993